### PR TITLE
docs: add Moltbot integration guide

### DIFF
--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -113,6 +113,7 @@ export default defineLoacaleConfig({
           { text: "Dify Integration", link: "/best-practices/dify" },
           { text: "Neovate Integration", link: "/best-practices/neovate-code" },
           { text: "Github Copilot", link: "/best-practices/github-copilot" },
+          { text: "Moltbot", link: "/best-practices/moltbot" },
         ],
       },
       {


### PR DESCRIPTION
- Add English and Chinese docs for Moltbot + ZenMux integration
- Cover two methods: PR branch (auto-discovery) and manual config
- Add Moltbot to Chinese sidebar navigation