### PR TITLE
feat: add reasoning and reasoning_details fields for multi-turn tool …

### DIFF
--- a/docs_source/en/api/openai/create-chat-completion-new.md
+++ b/docs_source/en/api/openai/create-chat-completion-new.md
@@ -16,9 +16,9 @@ head:
 POST https://zenmux.ai/api/v1/chat/completions
 ```
 
-The Create Chat Completion endpoint is compatible with OpenAI’s [Create Chat Completion](https://platform.openai.com/docs/api-reference/chat/create) API, and is used to run inference with chat-based LLMs.
+The Create Chat Completion endpoint is compatible with OpenAI’s [Create Chat Completion](https://platform.openai.com/docs/api-reference/chat/create) API, and is used to run inference for conversational LLMs.
 
-All parameters that *may* be supported by models are listed below. Parameter support varies by model; for the exact parameters supported by each model, see the model’s details page.
+The parameters below list all options that *may* be supported by different models. Parameter support varies by model; for the exact parameters supported by a given model, see that model’s detail page.
 
 ## Request headers
 
@@ -28,18 +28,18 @@ Bearer Token authentication
 
 ### Content-Type `string` <font color="red">Required</font>
 
-Request payload content type. The default is `application/json`.
+The request content type. The default is `application/json`.
 
 ## Request
 
 ### messages `array` <font color="red">Required</font>
 
-Prompts provided to the model as a list of conversation messages. Depending on the model’s capabilities, supported message content types may vary (e.g., text, images, audio, video). For the exact supported parameters, refer to each model provider’s documentation.
+Prompts provided to the model as a list of chat messages. Depending on model capabilities, supported message modalities may differ (e.g., text, images, audio, video). For details, refer to each model provider’s documentation.
 
-Each element in `messages` represents one conversation message. Each message consists of `role` and `content`, as detailed below:
+Each element in `messages` represents one chat message and consists of `role` and `content`:
 
 ::: details Developer message `object`
-Instructions provided by the developer that the model should follow regardless of what the user says. In `o1` and newer models, `developer` messages replace the previous `system` messages.
+Instructions provided by the developer. The model should follow these instructions regardless of what the user says. In o1 and newer models, the `developer` message replaces the previous `system` message.
 
 - content `string or array ` <font color="red">Required</font>
 
@@ -50,7 +50,7 @@ Instructions provided by the developer that the model should follow regardless o
 
   - Array of content parts `array`
 
-    An array of typed content parts. For Developer messages, only the `text` type is supported.
+    An array of content parts with defined types. For Developer messages, only the `text` type is supported.
     - text `string` <font color="red">Required</font>
 
       Text content.
@@ -61,15 +61,15 @@ Instructions provided by the developer that the model should follow regardless o
 
 - role `string` <font color="red">Required</font>
 
-  The role of the message author, which is `developer` in this case.
+  The role of the message author; in this case, `developer`.
 
 - name `string` <font color="gray">Optional</font>
 
-  An optional participant name. Provides the model with information to distinguish between participants with the same role.
+  An optional participant name. Helps the model distinguish between participants with the same role.
   :::
 
 ::: details System message `object`
-Instructions provided by the developer that the model should follow regardless of what the user says. In `o1` and newer models, you should use `developer` messages for this purpose.
+Instructions provided by the developer. The model should follow these instructions regardless of what the user says. In o1 and newer models, you should use `developer` messages for this purpose.
 
 - content `string or array ` <font color="red">Required</font>
 
@@ -80,7 +80,7 @@ Instructions provided by the developer that the model should follow regardless o
 
   - Array of content parts `array`
 
-    An array of typed content parts. For System messages, only the `text` type is supported.
+    An array of content parts with defined types. For System messages, only the `text` type is supported.
     - text `string` <font color="red">Required</font>
 
       Text content.
@@ -91,11 +91,11 @@ Instructions provided by the developer that the model should follow regardless o
 
 - role `string` <font color="red">Required</font>
 
-  The role of the message author, which is `system` in this case.
+  The role of the message author; in this case, `system`.
 
 - name `string` <font color="gray">Optional</font>
 
-  An optional participant name. Provides the model with information to distinguish between participants with the same role.
+  An optional participant name. Helps the model distinguish between participants with the same role.
   :::
 
 ::: details User message `object`  
@@ -106,49 +106,49 @@ A message sent to the model by the end user. In most chat scenarios, this is the
   The content of the User message.
   - Text content `string` <font color="red">Required</font>
 
-    Plain text content, the most common usage.
+    Plain text content (the most common usage).
 
   - Array of content parts `array` <font color="red">Required</font>
 
-    An array of multimodal content parts. Depending on the model’s capabilities, it may include text, images, audio, and more. Common types include:
+    An array of multimodal content parts. Depending on model capabilities, it can include content types such as text, images, audio, etc. Common types include:
     - Text part
-      - type `string` <font color="red">Required</font>, fixed to `text`
+      - type `string` <font color="red">Required</font>, always `text`
       - text `string` <font color="red">Required</font>, the text content
 
     - Image part (multimodal models only)
-      - type `string` <font color="red">Required</font>, set to `image_url`
+      - type `string` <font color="red">Required</font>, `image_url`
       - image_url `object` <font color="red">Required</font>
         - url `string` <font color="red">Required</font>, an image URL or a base64 Data URL
-        - detail `string` <font color="gray">Optional</font>, typical values: `low` / `high` / `auto`, used to control image analysis fidelity
+        - detail `string` <font color="gray">Optional</font>, typical values: `low` / `high` / `auto`, used to control image parsing fidelity
 
     - Audio part (audio-input models only)
-      - type `string` <font color="red">Required</font>, set to `input_audio`
+      - type `string` <font color="red">Required</font>, `input_audio`
       - input_audio `object` <font color="red">Required</font>
-        - data `string` <font color="red">Required</font>, base64 audio file content
+        - data `string` <font color="red">Required</font>, base64-encoded audio file content
         - format `string` <font color="red">Required</font>, e.g. `wav`, `mp3`
 
     - File part (File content part; models that support file input only)  
       Used to provide an entire file as context to the model (e.g., PDF, Office documents).
-      - type `string` <font color="red">Required</font>, fixed to `file`
+      - type `string` <font color="red">Required</font>, always `file`
       - file `object` <font color="red">Required</font>
         - file_id `string` <font color="gray">Optional</font>
-          - The file ID obtained from the file upload endpoint. This is the recommended way to reference a file.
+          - The file ID obtained via the file upload endpoint. This is the recommended way to reference a file.
         - file_data `string` <font color="gray">Optional</font>
-          - Base64-encoded file data, used to include the file content directly in the request body.
+          - Base64-encoded file data, for sending file content directly in the request body
         - filename `string` <font color="gray">Optional</font>
-          - File name, used to hint the file type to the model or display it in the console.
+          - The filename, used to hint the file type to the model or to display it in the console
 
 - role `string` <font color="red">Required</font>
 
-  The role of the message author, which is `user` in this case.
+  The author role of the message; in this case, `user`.
 
 - name `string` <font color="gray">Optional</font>
 
-  An optional participant name. Provides the model with information to distinguish between participants with the same role.  
+  An optional participant name. Helps the model distinguish between participants with the same role.  
   :::
 
 ::: details Assistant message `object`  
-A reply message sent by the model to the user. You can include these historical assistant messages in new requests so the model can continue reasoning with the full context.
+A reply message sent to the user by the model during the conversation. You can include these historical assistant messages in new requests so the model can continue reasoning with the full context.
 
 - content `string or array` Optional
 
@@ -159,7 +159,7 @@ A reply message sent by the model to the user. You can include these historical 
 
   - Array of content parts `array`
 
-    An array of typed content parts. It may include one or more content parts of type `text`, or **exactly one** content part of type `refusal`.
+    An array of content parts with defined types. It can contain one or more `text` parts, or **exactly one** `refusal` part.
     - Text content part `object` (text content part)
       - type `string` <font color="red">Required</font>  
         The type of the content part.
@@ -180,81 +180,110 @@ A reply message sent by the model to the user. You can include these historical 
 
 - role `string` <font color="red">Required</font>
 
-  The role of the message author, which is `assistant` in this case.
+  The author role of the message; in this case, `assistant`.
 
 - name `string` Optional
 
-  An optional participant name. Provides the model with information to distinguish between participants with the same role.
+  Optional participant name. Helps the model distinguish between participants with the same role.
 
 - audio `object or null` Optional
 
-  Data about a **previous model audio reply**, which can be referenced in subsequent turns.
+  Data about a **previous model audio response**, which can be referenced in subsequent turns.
   - id `string` <font color="red">Required</font>
 
-    The unique identifier of the previous audio reply.
+    The unique identifier of the previous audio response.
 
 - tool_calls `array` Optional
   - Function tool call `object`
     - id `string` <font color="red">Required</font>
 
-      Tool call ID, used to match `tool_call_id` in a subsequent Tool message.
+      The tool call ID, used to match `tool_call_id` in subsequent Tool messages.
 
     - type `string` <font color="red">Required</font>
 
-      Tool type. Currently only `function` is supported.
+      The tool type. Currently only `function` is supported.
 
     - function `object` <font color="red">Required</font>
       - name `string` <font color="red">Required</font>
 
-        The function name to call.
+        The name of the function to call.
 
       - arguments `string` <font color="red">Required</font>
 
         Function call arguments as a JSON string (generated by the model).  
-        Note: the model does not guarantee strictly valid JSON, and may include parameters not defined in the function schema. Validate on the application side before calling.
+        Note: The model is not guaranteed to generate strictly valid JSON and may include parameters not defined in the function schema. Validate on the application side before invoking.
 
     - Custom tool call `object`
       - id `string` <font color="red">Required</font>
 
-        Tool call ID, used to match `tool_call_id` in a subsequent Tool message.
+        The tool call ID, used to match `tool_call_id` in subsequent Tool messages.
 
       - type `string` <font color="red">Required</font>
 
-        Tool type, always `custom`.
+        The tool type. Always `custom`.
 
       - custom `object` <font color="red">Required</font>
         - name `string` <font color="red">Required</font>
 
-          The function name to call.
+          The name of the function to call.
 
         - input `string` <font color="red">Required</font>
 
-          The input for the custom tool call generated by the model.
+          The input for the custom tool call, generated by the model.
 
-- function_call `object or null` (Deprecated) Optional
+- function_call `object or null` (deprecated) Optional
 
-  Superseded by `tool_calls` and kept only for compatibility with the legacy format. Indicates the function name and arguments that the model suggests calling.
+  Replaced by `tool_calls` and retained only for backward compatibility. Indicates the function name and arguments the model suggests calling.
   - name `string` <font color="red">Required</font>  
-    The function name to call.
+    The name of the function to call.
 
   - arguments `string` <font color="red">Required</font>  
-     Function call arguments as a JSON string (generated by the model); likewise, this must be validated on the application side before actual execution.
+     Function call arguments as a JSON string (generated by the model). You must still validate on the application side before actually invoking.
+
+- reasoning `string` Optional
+
+  The assistant message’s reasoning text. When reasoning is enabled, the model’s reasoning content will appear in this field. In multi-turn conversations, you can pass this back to maintain continuity.
+
+- reasoning_details `array` Optional (**required for multi-turn tool-calling scenarios**)
+
+  An array with detailed reasoning information. **In multi-turn tool-calling scenarios with reasoning enabled, you must pass this field back in full—especially the `signature` field—otherwise subsequent turns will not work properly.**
+
+  Each element includes:
+  - type `string` <font color="red">Required</font>
+
+    The reasoning content type, e.g. `reasoning.text`.
+
+  - text `string` <font color="red">Required</font>
+
+    The reasoning text content.
+
+  - signature `string` <font color="red">Required</font>
+
+    A signed credential for the reasoning content. **This is the key field for maintaining reasoning context across turns and must be passed back unchanged.** The signature is generated by the model to verify integrity and continuity.
+
+  - format `string` <font color="gray">Optional</font>
+
+    Signature format identifier, e.g. `anthropic-claude-v1`.
+
+  - index `number` <font color="gray">Optional</font>
+
+    Index of the reasoning segment.
 
 :::
 
 ::: details Tool message `object`  
-A message used to pass the execution result of an external tool (function) call back to the model.
+A message used to return the execution result of an external tool (function) call back to the model.
 
 - content `string or array` <font color="red">Required</font>
 
-  The tool execution result content, usually text or structured data (serialized as a string).
+  The content of the tool execution result, typically text or structured data (serialized to a string).
   - Text content `string`
 
     The content of the Tool message.
 
   - Array of content parts `array`
 
-    An array of typed content parts. For Tool messages, only the `text` type is supported.
+    An array of content parts with defined types. For Tool messages, only the `text` type is supported.
     - text `string` <font color="red">Required</font>
 
       Text content.
@@ -265,96 +294,96 @@ A message used to pass the execution result of an external tool (function) call 
 
 - role `string` <font color="red">Required</font>
 
-  The role of the message author, which is `tool` in this case.
+  The author role of the message; in this case, `tool`.
 
 - tool_call_id `string` <font color="red">Required</font>
 
-  Corresponds to `tool_calls[i].id` in an assistant message, used to associate this tool result with that call.
+  Corresponds to an `assistant` message’s `tool_calls[i].id`, used to associate this tool result with that call.
 
 - name `string` <font color="gray">Optional</font>
 
-  The tool name (usually consistent with the function name declared in `tools`).  
+  The tool name (usually matches the function name declared in `tools`).  
   :::
 
-::: info Function message `object` <font color="red">Deprecated by the official API and not supported</font>
+::: info Function message `object` <font color="red">Deprecated by the official spec and not supported</font>
 :::
 
 ### model `string` <font color="red">Required</font>
 
-The model ID for this inference call, in the format `<provider>/<model_name>`, e.g. `openai/gpt-5`. You can obtain it from each model’s details page.
+The model ID for this inference request, in the format `<provider>/<model_name>`, e.g. openai/gpt-5. You can find it on each model’s detail page.
 
 ### max_completion_tokens `integer or null` <font color="gray">Optional</font>
 
-Limits the length of the generated output, including the reasoning process. If omitted, the model’s default limit is used. Each model’s maximum output length can be found on its details page.
+Limits the length of the model’s generated content, including reasoning. If omitted, the model’s default limit is used. The maximum generation length for each model is available on its detail page.
 
 ### temperature `number` <font color="gray">Optional</font>
 
 - Default: `1`
 - ZenMux does not enforce a range; values in `[0, 2]` are recommended.
 
-Sampling temperature controlling randomness: higher values increase randomness; lower values make outputs more deterministic. Typically tune either this or `top_p`.
+Sampling temperature to control randomness: higher values yield more randomness; lower values yield more deterministic output. Typically tuned as an alternative to `top_p`.
 
 ### top_p `number` <font color="gray">Optional</font>
 
 - Default: `1`
 
-Nucleus sampling parameter: sampling is restricted to tokens with cumulative probability mass up to `top_p`. For example, `top_p = 0.1` means only the top 10% probability mass is considered.
+Nucleus sampling parameter: only sample from tokens whose cumulative probability mass is within `top_p`. For example, `top_p = 0.1` means only consider tokens in the top 10% probability mass.
 
 ### n `integer or null` <font color="gray">Optional</font>
 
-Number of candidate completions to return. Currently only `n=1` is supported.
+Number of candidate responses to return. Currently only `n=1` is supported.
 
 ### frequency_penalty `number or null` <font color="gray">Optional</font>
 
 - Default: `0`
-- Range: `-2.0` ~ `2.0`
+- Range: `-2.0` to `2.0`
 
-Penalizes tokens that appear frequently. Larger values make the model less likely to repeat the same content, which can reduce repetitive output.
+Penalizes tokens that have appeared frequently. Higher values reduce repetition and can help avoid mechanical echoing.
 
 ### presence_penalty `number or null` <font color="gray">Optional</font>
 
 - Default: `0`
-- Range: `-2.0` ~ `2.0`
+- Range: `-2.0` to `2.0`
 
-Penalizes tokens based on whether they have **appeared at all**. Larger values encourage introducing new topics and reduce repeatedly discussing the same content.
+Penalizes tokens based on whether they have appeared at all. Higher values encourage introducing new topics and reduce repeatedly discussing the same content.
 
 ### stop `string | array | null` <font color="gray">Optional</font>
 
 - Default: `null`
-- Up to 4 stop sequences can be provided.
+- Up to 4 stop sequences
 
-When any stop sequence is generated, the model stops and the returned result does not include the stop sequence. Some newer reasoning models (e.g., `o3`, `o4-mini`) do not support this parameter.
+When the generated output matches any stop sequence, the model stops generating and the stop sequence is not included in the response. Some newer reasoning models (e.g. `o3`, `o4-mini`) do not support this parameter.
 
 ### logit_bias `object` <font color="gray">Optional</font>
 
 - Default: `null`
 
-Used to fine-tune the sampling probability of specified tokens. Keys are token IDs (integers) from the tokenizer; values are biases from `-100` to `100`.
+Used to fine-tune sampling probabilities for specific tokens. Keys are token IDs (integers) from the tokenizer; values are biases between `-100` and `100`.
 
-- Positive values: increase the likelihood the token is selected
-- Negative values: decrease the likelihood the token is selected
-- Extreme values (e.g., ±100): close to forcibly banning or forcing the token
+- Positive: increase the chance of selecting the token
+- Negative: decrease the chance of selecting the token
+- Extreme values (e.g. ±100): approximate forcing a token off/on
 
 ### logprobs `boolean or null` <font color="gray">Optional</font>
 
 - Default: `false`
 
-Whether to include log probability information for output tokens in the response.
+Whether to include log probabilities for output tokens in the response.
 
 ### top_logprobs `integer` <font color="gray">Optional</font>
 
-Specifies the **number of highest-probability tokens** returned per position (0–20), each with its logprob.
+Specifies the **number of most likely tokens** to return at each position (0–20), each with its logprob.
 
 ### tools `array` <font color="gray">Optional</font>
 
-Declares the list of tools the model may call in this conversation. Each element may be a custom tool or a function tool (a JSON-Schema-defined function).
+Declares a list of tools the model can call in this conversation. Each element can be a custom tool or a function tool (a function defined via JSON Schema).
 
 ### tool_choice `string or object` <font color="gray">Optional</font>
 
-Controls the model’s tool usage strategy: ([platform.openai.com](https://platform.openai.com/docs/api-reference/chat))
+Controls the model’s tool-usage strategy: ([platform.openai.com](https://platform.openai.com/docs/api-reference/chat))
 
 - `"none"`: do not call any tools
-- `"auto"`: the model decides whether to call tools and which tools to call
+- `"auto"`: let the model decide whether and which tools to call
 - `"required"`: the model must call at least one tool in this turn
 - Specify a single tool: `{"type": "function", "function": {"name": "my_function"}}`
 
@@ -364,94 +393,94 @@ Controls the model’s tool usage strategy: ([platform.openai.com](https://platf
 
 Whether to allow the model to call multiple tools (functions) **in parallel** within a single response.
 
-### reasoning_effort `string` <font color="gray">Optional</font> (Reasoning models)
+### reasoning_effort `string` <font color="gray">Optional</font> (reasoning models)
 
-Controls how much effort a **reasoning model** invests in thinking: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, etc. Default values and supported ranges vary by model.
+Controls how much effort a **reasoning model** puts into thinking: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, etc. Defaults and supported ranges vary by model.
 
 ### verbosity `string` <font color="gray">Optional</font>
 
 - Default: `"medium"`
 
-Constrains the verbosity of the model output: `low` (concise), `medium` (balanced), `high` (more detailed).
+Constrains output verbosity: `low` (concise), `medium` (balanced), `high` (more detailed).
 
 ### web_search_options `object` <font color="gray">Optional</font>
 
-Configures the behavior of the **web search tool**, allowing the model to proactively retrieve the latest information from the internet before generating an answer.
+Configures the behavior of the **web search tool**, enabling the model to proactively retrieve up-to-date information from the internet before answering.
 
 ### metadata `object` <font color="gray">Optional</font>
 
-Allows up to 16 key-value pairs to be attached as structured business metadata for easier querying in logs, search, or management UIs.
+Allows up to 16 key-value pairs as structured business metadata for logging, retrieval, or querying in management UIs.
 
 ### stream `boolean or null` <font color="gray">Optional</font>
 
 - Default: `false`
 
-Whether to enable **streaming output** (Server-Sent Events). When `true`, the result is returned in chunks as an event stream.
+Whether to enable **streaming output** (Server-Sent Events). When `true`, results are returned as an event stream in chunks.
 
 ### stream_options `object` <font color="gray">Optional</font>
 
-Only effective when `stream: true`. Used to configure streaming behavior, such as including usage information at the end of the stream.
+Only effective when `stream: true`, used to configure streaming behavior, such as whether to include usage information at the end of the stream.
 
 ### provider `object` <font color="gray">Optional</font>
 
-Used to configure routing and failover for this request across multiple model providers (e.g., OpenAI, Anthropic, Google).
-If not provided, the project or model’s default routing policy is used.
+Used to configure routing and failover across multiple model providers (e.g., OpenAI, Anthropic, Google) for this request.  
+If not specified, the project’s or model’s default routing strategy is used.
 
 #### routing `object` <font color="red">Required</font>
 
-Routing policy configuration, determining how to select and distribute requests across multiple providers.
+Routing policy configuration that determines how requests are selected and distributed among multiple providers.
 
 ##### type `string` <font color="red">Required</font>
 
 Routing type. Supported values:
 
 - `priority`
-  Select providers in priority order: try the first; if it fails, try the next (can be used with fallback).
+  Select providers by priority order: try the first, then the next on failure (can be used with fallback).
 - `round_robin`
-  Round-robin distribution: evenly distribute traffic across providers.
+  Round-robin distribution: evenly distribute request traffic across providers.
 - `least_latency`
-  Lowest-latency first: select the currently fastest provider based on historical/real-time statistics.
+  Lowest-latency first: choose the currently fastest provider based on historical/real-time stats.
 
 ##### primary_factor `string` <font color="gray">Optional</font>
 
-The primary factor when multiple providers are available. For example:
+The primary consideration when multiple providers are available. For example:
 
 - `cost`
   Prefer lower-cost providers
 - `speed`
-  Prefer faster-response providers
+  Prefer faster-responding providers
 - `quality`
   Prefer higher-quality providers (e.g., stronger models / more stable service)
 
-Actual behavior is combined with `type`. For example, when `type = "priority"`, `primary_factor` mainly influences priority ordering.
+Actual behavior works in conjunction with `type`. For example, when `type = "priority"`, `primary_factor` mainly affects the priority sorting logic.
 
 ##### providers `array` <font color="red">Required</font>
 
-List of model providers that can participate in routing. Example: `["openai", "anthropic", "google"]`
+The list of model providers that can participate in routing. Example: `["openai", "anthropic", "google"]`
 
 #### fallback `string` <font color="gray">Optional</font>
 
-Failover policy. When the selected provider returns an error (e.g., timeout, insufficient quota, service unavailable), this controls how automatic switching occurs:
+Failover strategy. When the currently selected provider fails (e.g., timeout, insufficient quota, service unavailable), how to automatically switch:
 
-`"true"`: enable automatic failover. When the current provider is unavailable, automatically try other available providers according to the routing policy.
+`"true"`: Enable automatic failover. When the current provider is unavailable, automatically try other available providers in the list according to the routing policy.
 
-`"false"`: disable failover. If the current provider call fails, return the error directly and do not try other providers.
+`"false"`: Disable failover. If the current provider call fails, return an error immediately without trying other providers.
 
-`"<provider_name>"`: explicitly specify a fixed fallback provider, e.g. `"anthropic"`:
+`"<provider_name>"`: Explicitly specify a fixed fallback provider, e.g. `"anthropic"`:
 
-Prefer the provider selected by the primary routing policy
-If it fails, switch to the specified fallback provider
+Use the provider selected by the primary routing policy first  
+If it fails, switch to the specified fallback provider  
 If both primary + fallback fail, return an error
 
 ### model_routing_config `object` <font color="gray">Optional</font>
 
-Used to configure selection and routing within **different models under the same provider** for this request (e.g., how to choose among `gpt-4o`, `gpt-4-turbo`, `claude-3-5-sonnet`).
+Used to configure selection and routing across different models **within the same provider** for this request (e.g., how to choose among `gpt-4o`, `gpt-4-turbo`, `claude-3-5-sonnet`).
 
-If not provided, the project or SDK default model selection policy is used (e.g., default model, default task-type mapping, etc.).
+If not specified, the project or SDK default model selection strategy is used (e.g., default model, default task-type mapping, etc.).
 
 #### available_models `array` <font color="red">Required</font>
 
-A list of **model names** that can participate in routing or be considered as candidates.
+A list of **model names** available for routing or as candidates.
 
 #### preference `string` <font color="gray">Optional</font>
 
@@ -459,21 +488,21 @@ Preferred model name.
 
 #### task_info `object` <font color="gray">Optional</font>
 
-Task metadata used to determine the specific model or parameters **based on task type and complexity**.
+Task metadata used to decide the specific model or parameters **based on task type and complexity**.
 
-Internal fields:
+Fields:
 
 ##### task_type `string` <font color="red">Required</font>
 
-Task type, used to express the purpose of the request for routing or automatic parameter selection.
+Task type, expressing what the request is for, to support routing or automatic parameter selection.
 
-- Example values:
+- Example supported values:
   - `"chat"` — conversational tasks (multi-turn chat, assistant Q&A)
   - `"completion"` — general text generation/completion
   - `"embedding"` — vectorization/semantic embedding
-- Uses:
-  - Set different default models or quota policies per task type
-  - Combine with `complexity` to decide whether to use a stronger model
+- Purpose:
+  - Set different default models or quota policies by task type
+  - Work with `complexity` to decide whether to use stronger models
 
 ##### complexity `string` <font color="gray">Optional</font>
 
@@ -481,44 +510,44 @@ Task complexity, describing the difficulty or importance of the request.
 
 - Supported values:
   - `"low"` — simple tasks (short answers, simple rewrites)
-  - `"medium"` — medium complexity (general Q&A, basic code, routine analysis)
+  - `"medium"` — moderate complexity (general Q&A, basic code, routine analysis)
   - `"high"` — high complexity (long-document analysis, complex programming, large-scale reasoning)
-- Uses:
-  - Select different tiers of models (e.g., cheaper models for low complexity, stronger models for high complexity)
-  - Control timeouts, retry policies, etc.
+- Purpose:
+  - Choose models at different tiers based on complexity (e.g., cheaper models for low complexity; stronger models for high complexity)
+  - Also used to control timeouts, retry strategies, etc.
 
 ##### additional_properties `object` <font color="gray">Optional</font>
 
-Additional task-related fields as a freely extensible key-value map.
+Task-related extension fields, as free-form key-value pairs.
 
 #### additional_properties `object` <font color="gray">Optional</font>
 
-Additional fields for the model routing configuration itself, used to attach extra control information beyond the standard structure.
+Extension fields for the model routing configuration itself, used to attach extra control information beyond the standard structure.
 
 ### reasoning `object` <font color="gray">Optional</font>
 
-Used to configure behavior related to the **reasoning process (chain-of-thought / reasoning trace)**, including whether it’s enabled, depth/length controls, and whether reasoning content is exposed.
+Used to configure behaviors related to the reasoning process (chain-of-thought / reasoning trace), including whether to enable it, depth/length controls, and whether to expose reasoning content externally.
 
-If not provided, the system or model uses the default reasoning policy.
+If not specified, the system or model uses its default reasoning strategy.
 
 #### enabled `boolean` <font color="red">Required</font>
 
-Whether to enable an explicit reasoning process.
+Whether to enable explicit reasoning.
 
 - `true`: the model uses (and, when allowed, outputs) more detailed reasoning steps
-- `false`: the model provides only a conclusion-level answer without explicitly expanding reasoning (or expands as little as possible)
+- `false`: the model provides only a conclusion (or minimizes explicit reasoning)
 
 #### effort `string` <font color="gray">Optional</font>
 
-Reasoning effort level, used to balance **thinking depth / reasoning granularity** against **cost / latency**.
+Reasoning effort level, balancing **depth / granularity** against **cost / latency**.
 
 - Supported values:
-  - `"low"` — lightweight reasoning: faster answers with fewer details
+  - `"low"` — lightweight reasoning: faster answers, fewer details
   - `"medium"` — moderate reasoning: a balanced choice for most tasks
   - `"high"` — deep reasoning: more detailed analysis, higher token usage and latency
 - Typical usage:
   - Latency-sensitive online services: prefer `"low"` or `"medium"`
-  - High-accuracy tasks: prefer `"high"`
+  - Mission-critical correctness: prefer `"high"`
 
 #### max_tokens `number` <font color="gray">Optional</font>
 
@@ -526,15 +555,15 @@ Maximum token limit for the reasoning process (not the final answer).
 
 #### exclude `boolean` <font color="gray">Optional</font>
 
-Whether to **exclude the reasoning process from the user-facing output**.
+Whether to **exclude reasoning content from the user-visible response**.
 
 - `false`:
-  - Reasoning content may be returned together with the final answer (e.g., during debugging or tool development)
+  - Reasoning can be returned alongside the final answer (e.g., during debugging/tool development)
 - `true`:
-  - Reasoning content is used internally only and not exposed to the user (typical production setting)
-- Uses:
-  - Meet safety and compliance requirements (do not expose chain-of-thought)
-  - During development/debugging, set to `false` to observe model reasoning and iterate on prompts and policies
+  - Reasoning is used internally only and not exposed to the user (typical production setting)
+- Purpose:
+  - Meet security/compliance requirements (do not expose chain-of-thought)
+  - In development/debugging, set to `false` to observe the model’s reasoning and iterate on prompts/policies
 
 #### usage `object` <font color="gray">Optional</font>
 
@@ -542,15 +571,15 @@ Usage statistics
 
 ##### include `boolean` <font color="red">Required</font>
 
-Whether to include usage statistics in the response.
+Whether to include usage statistics in the response
 
 ### response_format `object` <font color="gray">Optional</font>
 
-An object that specifies a required output format for the model.
+An object that specifies the required output format for the model.
 
-Set to `{ "type": "json_schema", "json_schema": {...} }` to enable structured outputs and ensure the model matches your provided JSON schema.
+Set to `{ "type": "json_schema", "json_schema": {...} }` to enable structured outputs and ensure the model matches the JSON Schema you provide.
 
-Set to `{ "type": "json_object" }` to enable legacy JSON mode and ensure the model generates valid JSON. For models that support it, `json_schema` is preferred.
+Set to `{ "type": "json_object" }` to enable legacy JSON mode and ensure the generated message is valid JSON. For models that support it, `json_schema` is preferred.
 
 :::details Text `object`
 
@@ -562,15 +591,15 @@ Set to `{ "type": "json_object" }` to enable legacy JSON mode and ensure the mod
 :::details JSON schema `object`
 
 - json_schema `object` <font color="red">Required</font>
-  The JSON schema that defines the response format.
+  The JSON Schema that defines the response format.
   - name `string` <font color="red">Required</font>
-    The name of the response format. Must be a-z, A-Z, 0-9, or include underscores and hyphens; max length is 64.
+    The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores and dashes; maximum length is 64.
   - schema `object` <font color="gray">Optional</font>
-    The response format schema, described as a JSON Schema object.
+    The schema for the response format, described as a JSON Schema object.
   - strict `boolean` <font color="gray">Optional</font>
     Whether to strictly follow the JSON schema.
   - description `string` <font color="gray">Optional</font>
-    A description of the response format’s purpose; the model uses it to determine how to respond in that format.
+    A description of the response format’s purpose. The model uses this description to determine how to respond in that format.
 - type `string` <font color="red">Required</font>
   The type of the response format being defined. Always `json_schema`.
 
@@ -585,27 +614,27 @@ Set to `{ "type": "json_object" }` to enable legacy JSON mode and ensure the mod
 
 ### Unsupported fields
 
-| Field name              | Type          | Supported                                           | Notes                                                                                  |
-| ----------------------- | ------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| audio                   | object/null   | <span style="white-space: nowrap;">❌ Not supported</span> | Audio output parameters                                                                 |
-| modalities              | array         | ❌ Not supported                                    | Output modalities                                                                       |
-| functions               | array         | ❌ Not supported                                    | Deprecated; not accepted                                                                |
-| function_call           | string/object | ❌ Not supported                                    | Deprecated; not accepted                                                                |
-| prompt_cache_key        | string        | ❌ Not supported                                    | Prompt cache key                                                                        |
-| prompt_cache_retention  | string        | ❌ Not supported                                    | Cache retention policy                                                                  |
-| safety_identifier       | string        | ❌ Not supported                                    | Safety identifier                                                                       |
-| store                   | bool/null     | ❌ Not supported                                    | Store this conversation                                                                 |
-| service_tier            | string        | ❌ Not supported                                    | Service tier                                                                            |
-| prediction              | object        | ❌ Not supported                                    | Predicted output configuration                                                          |
-| seed                    | int/null      | ❌ Not supported                                    | Sets a random seed for sampling; marked deprecated.                                     |
-| user                    | string        | ❌ Not supported                                    | Legacy user identifier field, largely replaced by `safety_identifier` and `prompt_cache_key`. |
-| max_tokens              | int/null      | ❌ Not supported                                    | Deprecated; replaced by `max_completion_tokens`                                         |
+| Field name              | Type          | Supported                                            | Description                                                                                              |
+| ----------------------- | ------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| audio                   | object/null   | <span style="white-space: nowrap;">❌ Not supported</span> | Audio output parameters                                                                                  |
+| modalities              | array         | ❌ Not supported                                     | Output modality types                                                                                    |
+| functions               | array         | ❌ Not supported                                     | Deprecated; this parameter is not accepted                                                               |
+| function_call           | string/object | ❌ Not supported                                     | Deprecated; this parameter is not accepted                                                               |
+| prompt_cache_key        | string        | ❌ Not supported                                     | Prompt cache key                                                                                         |
+| prompt_cache_retention  | string        | ❌ Not supported                                     | Cache retention policy                                                                                   |
+| safety_identifier       | string        | ❌ Not supported                                     | Safety identifier                                                                                        |
+| store                   | bool/null     | ❌ Not supported                                     | Store this conversation                                                                                  |
+| service_tier            | string        | ❌ Not supported                                     | Service tier                                                                                             |
+| prediction              | object        | ❌ Not supported                                     | Predicted outputs configuration                                                                          |
+| seed                    | int/null      | ❌ Not supported                                     | Random seed for sampling; deprecated                                                                     |
+| user                    | string        | ❌ Not supported                                     | Legacy user identifier; now primarily replaced by `safety_identifier` and `prompt_cache_key`.            |
+| max_tokens              | int/null      | ❌ Not supported                                     | Deprecated; replaced by `max_completion_tokens`                                                          |
 
 ## Response
 
-### Non-streaming: returns a “full chat completion object”
+### Non-streaming: returns a “complete chat completion object”
 
-When `stream: false` (or omitted), the API returns a complete **chat.completion** object. Field descriptions are expanded in the same order as the table above.
+When `stream: false` (or omitted), the endpoint returns a complete **chat.completion** object. Field descriptions follow the same order as the table above.
 
 ---
 
@@ -613,7 +642,7 @@ When `stream: false` (or omitted), the API returns a complete **chat.completion*
 
 #### choices `array`
 
-A list of chat completion choices. Corresponds 1:1 to the request’s `n`. Currently only `n = 1` is supported, so it typically contains just one element.
+A list of chat completion choices. It corresponds one-to-one with `n` in the request. Currently only `n = 1` is supported, so it typically contains a single element.
 
 ---
 
@@ -621,13 +650,13 @@ A list of chat completion choices. Corresponds 1:1 to the request’s `n`. Curre
 
 #### finish_reason `string`
 
-The reason the model stopped generating tokens. Common values:
+The reason the model stopped generating tokens. Common values include:
 
 - `stop`: reached a natural stopping point or hit a stop sequence
 - `length`: reached the maximum token limit specified in the request
 - `content_filter`: content was omitted due to a content filter
-- `tool_calls`: the model invoked tools (`tool_calls`)
-- `function_call`: the model invoked a function (legacy, deprecated)
+- `tool_calls`: the model called a tool (`tool_calls`)
+- `function_call`: the model called a function (legacy, deprecated)
 
 #### index `integer`
 
@@ -635,7 +664,7 @@ The index of this choice in the `choices` array, starting from 0.
 
 #### logprobs `object`
 
-Log probability information for this choice, used to analyze probability distributions for each output token. Present only when `logprobs`-related parameters are set in the request.
+Log probability information for this choice, used to inspect the probability distribution for each output token. Present only when `logprobs`-related parameters are set in the request.
 
 ---
 
@@ -646,22 +675,22 @@ Log probability information for this choice, used to analyze probability distrib
 A list of “message content tokens” with log probability information. Each element describes a token and its candidate tokens:
 
 - bytes `array`  
-  A list of integers representing the UTF‑8 byte representation of the token. In some languages or for emoji, a character may span multiple tokens; combining these bytes can reconstruct the correct text. If the token has no byte representation, this is `null`.
+  A list of integers representing the UTF‑8 bytes for the token. In some languages or for emojis, a character may consist of multiple tokens; merging these bytes reconstructs the correct text. If the token has no byte representation, this is `null`.
 
 - logprob `number`  
-  The log probability of the token. If it is not among the top 20 most likely tokens, `-9999.0` is commonly used to indicate “extremely unlikely”.
+  The log probability of the token. If the token is not among the top 20 most likely tokens, `-9999.0` is typically used to indicate “extremely unlikely”.
 
 - token `string`  
   The text representation of the current output token.
 
 - top_logprobs `array`  
-  A list of the most likely candidate tokens at this position and their log probabilities. In rare cases, the actual number returned may be less than requested.
+  A list of the most likely candidate tokens and their log probabilities at this position. In rare cases, the returned count may be smaller than requested.
   - bytes `array`  
-    The UTF‑8 byte representation of the candidate token; `null` if not available.
+    UTF‑8 bytes for the candidate token; `null` if not available.
   - logprob `number`  
-    The candidate token’s log probability.
+    The log probability of the candidate token.
   - token `string`  
-    The text of a candidate token.
+    The text of the candidate token.
 
 ---
 
@@ -669,22 +698,22 @@ A list of “message content tokens” with log probability information. Each el
 
 #### refusal `array`
 
-A list of “refusal content tokens” with log probability information. Used to analyze token probabilities when the model outputs a refusal message.
+A list of “refusal content tokens” with log probability information. When the model outputs a refusal, this is used to inspect token probabilities for the refusal text.
 
 - bytes `array`  
-  The UTF‑8 byte representation of the refusal token; `null` if not available.
+  UTF‑8 bytes for the refusal token; `null` if not available.
 - logprob `number`  
-  The refusal token’s log probability. If it is not among the top 20, it is typically `-9999.0`.
+  Log probability of the refusal token; typically `-9999.0` when not in the top 20.
 - token `string`  
-  The text of a token in the refusal content.
+  The text of a token within the refusal content.
 - top_logprobs `array`  
-  A list of the most likely refusal token candidates at this position.
+  The most likely candidate refusal tokens at this position.
   - bytes `array`  
-    The UTF‑8 byte representation of a candidate refusal token.
+    UTF‑8 bytes for the candidate refusal token.
   - logprob `number`  
-    The candidate refusal token’s log probability.
+    The log probability of the candidate refusal token.
   - token `string`  
-    The text of a candidate token in the refusal content.
+    The text of the candidate token within the refusal content.
 
 ---
 
@@ -692,7 +721,7 @@ A list of “refusal content tokens” with log probability information. Used to
 
 #### message `object`
 
-The full chat completion message generated by the model.
+The complete chat completion message generated by the model.
 
 ---
 
@@ -700,75 +729,75 @@ The full chat completion message generated by the model.
 
 #### reasoning `string` (ZenMux extension)
 
-Text of the reasoning process, used to show the model’s thought process or intermediate analysis. Whether it is returned depends on the model and the reasoning configuration in the request.
+Reasoning text content, used to display the model’s thought process or intermediate analysis. Whether it is actually returned depends on the model and the reasoning configuration in the request.
 
-#### reasoning_content `string` (ZenMux extension)
+#### reasoning_details `string` (ZenMux extension)
 
-The main body of the reasoning content, usually more complete or detailed than `reasoning`, and can serve as the primary carrier for chain-of-thought.
+The main body of the reasoning text, typically more complete or detailed than `reasoning`, and can serve as the primary carrier for chain-of-thought.
 
 #### content `string`
 
-The main content of the message, typically the model’s natural-language reply to the user. Some multimodal models may return structured content, but overall it follows the OpenAI chat format.
+The main message content, typically the model’s natural-language reply to the user. Some multimodal models may return structured content, but overall it follows the OpenAI chat format.
 
 #### refusal `string or null`
 
-If the model refuses to perform the user request in this turn, this contains the refusal message text generated by the model; otherwise it is `null`.
+If the model refuses to fulfill the user request in this turn, this contains the refusal message text; otherwise `null`.
 
 #### role `string`
 
-The author role of the message. For model reply messages, it is `"assistant"`.
+The author role. For a model reply, it is `"assistant"`.
 
 #### annotations `array`
 
-A list of annotations for the message. When using tools such as web search, it is used to carry URL citations and similar information.
+A list of annotations. When using tools such as web search, it can carry URL citations and similar references.
 
 - type `string`  
-  The type of URL citation. Currently fixed to `url_citation`.
+  The type of URL citation; currently always `url_citation`.
 - url_citation `object`  
   URL citation details when using web search.
   - end_index `integer`  
-    The index of the last character of the URL citation in the message `content`.
+    The index of the last character of this citation within the message `content`.
   - start_index `integer`  
-    The index of the first character of the URL citation in the message `content`.
+    The index of the first character of this citation within the message `content`.
   - title `string`  
-    Title of the web resource.
+    The title of the web resource.
   - url `string`  
     The URL of the web resource.
 
 #### audio `object`
 
-When an audio output modality is requested, this object contains the model’s audio response data.
+When audio output modality is requested, this object contains the model’s audio response data.
 
 - data `string`  
-  Base64-encoded audio bytes generated by the model; the format is specified in the request.
+  Base64-encoded audio bytes generated by the model, in the requested format.
 - expires_at `integer`  
-  Unix timestamp (seconds) after which the audio response is no longer available server-side for subsequent multi-turn conversations.
+  Unix timestamp (seconds) after which this audio response is no longer available on the server for subsequent multi-turn conversations.
 - id `string`  
-  Unique identifier for this audio response.
+  The unique identifier of this audio response.
 - transcript `string`  
-  The transcript (text) corresponding to the audio content.
+  The transcript (transcribed text) corresponding to the audio content.
 
 #### function_call `object`
 
-Deprecated function-call field. Replaced by `tool_calls` and retained only for compatibility with legacy formats. Indicates the function name and arguments the model suggests calling.
+Deprecated function-call field, replaced by `tool_calls` and retained only for backward compatibility. Indicates the function name and parameters the model suggests calling.
 
 - arguments `string`  
-  Function arguments as a JSON string. Note that the model does not guarantee strictly valid JSON and may include fields not defined in the schema; you must parse and validate before calling.
+  Function arguments as a JSON string. Note that the model is not guaranteed to produce strictly valid JSON and may include fields not defined in the schema; you should parse and validate before invocation.
 - name `string`  
   The function name to call.
 
 #### tool_calls `array`
 
-New tool call list. Each element describes a tool call, which can be a “function tool call” or a “custom tool call”. Models may call multiple tools in parallel in a single response.
+The new tool-call list. Each element describes one tool call, which can be a “function tool call” or a “custom tool call”. Models may call multiple tools in parallel within a single response.
 
 - id `string`  
-  Unique ID for the tool call, used to match `tool_call_id` in subsequent `tool` messages.
+  Unique ID of the tool call, used to match `tool_call_id` in subsequent `tool` messages.
 - type `string`  
-  Tool type. The current standard is `function`; ZenMux may support other types such as `custom` via extensions.
+  Tool type. The current standard is `function`; ZenMux may support other types such as `custom` in extensions.
 - function `object`  
-  When `type = "function"`, represents the function the model calls.
+  When `type = "function"`, indicates the function the model calls.
   - arguments `string`  
-    Function call arguments as a JSON string. The model may not always generate valid JSON and may produce fields not defined in the schema; validate before calling.
+    Function call arguments as a JSON string. The model may not always generate valid JSON and may include fields not defined in the schema; validate before invocation.
   - name `string`  
     The function name to call.
 
@@ -782,11 +811,11 @@ Unix timestamp (seconds) when the chat completion was created.
 
 #### id `string`
 
-Unique identifier for this chat completion.
+Unique identifier of this chat completion.
 
 #### model `string`
 
-The model identifier used to generate this completion, e.g. `openai/gpt-5`.
+Model identifier used for this completion, e.g. `openai/gpt-5`.
 
 #### object `string`
 
@@ -794,54 +823,54 @@ Object type. For non-streaming responses, this is always `chat.completion`.
 
 #### service_tier `string`
 
-The service type/tier used to handle the request. ZenMux does not restrict values; if the upstream model returns this field, it will be passed through.
+The service tier/type used to process the request. ZenMux does not constrain values; if the upstream model returns this field, it will be passed through.
 
 #### system_fingerprint `string`
 
-A fingerprint of the backend configuration used for this request, used to identify the underlying service version or cluster. Passed through if provided upstream.
+Backend configuration fingerprint for this request, used to identify the underlying service version or cluster. Passed through if provided upstream.
 
 #### usage `object`
 
-Usage statistics for this request, including prompt and completion token counts.
+Usage statistics for this request, including token counts for prompts and completions.
 
 - completion_tokens `integer`  
   Number of tokens used in the generated completion.
 - prompt_tokens `integer`  
   Number of tokens used in the input prompt (messages, etc.).
 - total_tokens `integer`  
-  Total tokens used in the request (`prompt_tokens + completion_tokens`).
+  Total tokens used (`prompt_tokens + completion_tokens`).
 
 - completion_tokens_details `object`  
   Further breakdown of completion tokens.
   - accepted_prediction_tokens `integer`  
-    When using Predicted Outputs, the number of predicted tokens that actually appear in the completion. This field is generally not used by current models.
+    When using Predicted Outputs, the number of predicted tokens that actually appeared in the completion. Typically unused by current models.
   - audio_tokens `integer`  
-    Number of tokens consumed by the model’s audio output.
+    Tokens consumed by audio output generated by the model.
   - reasoning_tokens `integer`  
-    Number of tokens generated for reasoning (even if not fully displayed to the user, they still count toward usage).
+    Tokens generated for the reasoning process (even if not fully shown to the user).
   - rejected_prediction_tokens `integer`  
-    When using Predicted Outputs, the number of predicted tokens that did not appear in the completion; these tokens still count toward billing and context window limits. Generally not used by current models.
+    When using Predicted Outputs, the number of predicted tokens that did not appear in the completion; these tokens still count toward billing and context-window limits. Typically unused.
 
 - prompt_tokens_details `object`  
   Breakdown of prompt tokens.
   - audio_tokens `integer`  
-    Number of tokens consumed by audio inputs in the prompt.
+    Tokens consumed by audio input in the prompt.
   - cached_tokens `integer`  
-    Number of tokens in the prompt that were served from cache (Prompt Caching).
+    Tokens matched via prompt caching.
 
 ---
 
-### Streaming: returns multiple “chat completion chunk object” events
+### Streaming: returns multiple “chat completion chunk objects”
 
-When `stream: true`, the API returns **chat.completion.chunk** objects multiple times via SSE (Server‑Sent Events). The client must consume and concatenate them in order. Field descriptions below are also expanded in the same order as the table.
+When `stream: true`, the endpoint returns **chat.completion.chunk** objects multiple times via SSE (Server-Sent Events). Clients should consume and concatenate chunks in order. Field descriptions follow the same order as the table above.
 
 ---
 
-### Top-level field: `choices` (streaming chunks)
+### Top-level field: `choices` (streamed chunks)
 
 #### choices `array`
 
-A list of chat completion choices. If `n > 1`, it may contain multiple elements. When `stream_options: {"include_usage": true}` is set, the final chunk may have an empty `choices` array and include only `usage` information.
+A list of completion choices. If `n > 1`, it can contain multiple elements. When `stream_options: {"include_usage": true}` is set, the final chunk may have an empty `choices` array and carry only `usage` information.
 
 ---
 
@@ -849,53 +878,53 @@ A list of chat completion choices. If `n > 1`, it may contain multiple elements.
 
 #### delta `object`
 
-Incremental conversational content generated by the streaming response—i.e., what is “new” relative to previous chunks.
+Incremental content produced by the streaming model response—i.e., what is “new” compared to previous chunks.
 
 - reasoning `string` (ZenMux extension)  
-  Incremental text for the reasoning process, streamed chunk by chunk.
+  Incremental reasoning text, used to stream reasoning information chunk by chunk.
 - reasoning_content `string` (ZenMux extension)  
-  Incremental fragments of the reasoning body, typically used together with `reasoning` to assemble full reasoning text.
+  Incremental fragment of the reasoning main body, typically used with `reasoning` to reconstruct the full reasoning text.
 - content `string`  
-  Incremental message body content for this chunk. Clients should concatenate `content` across chunks to form the full reply.
-- function_call `object` (Deprecated)  
-  Incremental legacy function-call information. Replaced by `tool_calls`, but still parseable.
+  Incremental message content for this chunk. The client should concatenate `content` across chunks to build the full reply.
+- function_call `object` (deprecated)  
+  Legacy incremental function-call information, replaced by `tool_calls` but still parseable.
   - arguments `string`  
-    Incremental JSON fragment for function arguments; must be concatenated across chunks before parsing.
+    Incremental JSON fragment of function arguments; must be concatenated across chunks before parsing.
   - name `string`  
-    The function name to call, typically present in the first chunk of the call.
+    The function name to call; typically appears in the first chunk of the call.
 
 - refusal `string`  
   Incremental refusal message fragment for this chunk.
 - role `string`  
-  The author role for this message, usually `"assistant"` in the first chunk.
+  The author role for this message, typically `"assistant"` in the first chunk.
 - tool_calls `array`  
-  List of incremental tool-call information.
+  Incremental tool-call information list.
 
   For each incremental tool-call element:
   - index `integer`  
-    The position of this tool call in the `tool_calls` array.
+    The position of this tool call within the `tool_calls` array.
   - function `object`  
-    Incremental function tool-call info.
+    Incremental information for a function tool call.
     - arguments `string`  
-      Incremental fragment of the JSON string for function arguments; concatenate across chunks before parsing.
+      Incremental fragment of the JSON string for function-call arguments; must be concatenated across chunks before parsing.
     - name `string`  
-      The function name to call, typically provided at the start of the tool call.
+      The function name to call; typically provided at the start of the tool call.
 
   - id `string`  
-    Tool call ID, typically provided on first occurrence for later association with `tool` messages.
+    The tool call ID; typically provided on first appearance for later association with `tool` messages.
   - type `string`  
-    Tool type. Currently only `function` is supported.
+    The tool type; currently only `function` is supported.
 
 #### finish_reason `string or null`
 
-The reason generation stopped in the current chunk:
+Why generation stopped for this chunk:
 
 - `stop`: natural end or hit a stop sequence
-- `length`: reached the maximum token limit
+- `length`: reached the maximum generation token limit
 - `content_filter`: content was filtered
-- `tool_calls`: triggered tool calling
-- `function_call`: triggered legacy function calling
-- `null`: generation has not finished; more chunks will follow
+- `tool_calls`: tool call triggered
+- `function_call`: legacy function call triggered
+- `null`: not finished yet; more chunks will follow
 
 #### index `integer`
 
@@ -903,7 +932,7 @@ The index of this choice in the `choices` array.
 
 #### logprobs `object`
 
-Log probability information for this choice in the current chunk. Same structure as non-streaming `logprobs`, but only for newly generated tokens.
+Log probability structure for the current chunk, same as non-streaming `logprobs`, but only for the “new” tokens.
 
 ---
 
@@ -911,22 +940,22 @@ Log probability information for this choice in the current chunk. Same structure
 
 #### content `array`
 
-A list of newly generated “message content tokens” in the current chunk.
+A list of “message content tokens” newly generated in the current chunk.
 
 - bytes `array`  
-  UTF‑8 byte representation of the current token.
+  UTF‑8 bytes for the current token.
 - logprob `number`  
-  Log probability of the current token; `-9999.0` if not among the top 20 most likely tokens.
+  Log probability for the current token; `-9999.0` if not in the top 20 most likely tokens.
 - token `string`  
   Text representation of the current output token.
 - top_logprobs `array`  
-  List of the most likely candidate tokens at this position.
+  Candidate tokens most likely at this position.
   - bytes `array`  
-    UTF‑8 byte representation of a candidate token.
+    UTF‑8 bytes for the candidate token.
   - logprob `number`  
-    Log probability of the candidate token.
+    Log probability for the candidate token.
   - token `string`  
-    Text of a candidate token.
+    Text of the candidate token.
 
 ---
 
@@ -934,22 +963,22 @@ A list of newly generated “message content tokens” in the current chunk.
 
 #### refusal `array`
 
-A list of newly generated “refusal content tokens” in the current chunk.
+A list of “refusal content tokens” newly generated in the current chunk.
 
 - bytes `array`  
-  UTF‑8 byte representation of the refusal token.
+  UTF‑8 bytes for the refusal token.
 - logprob `number`  
-  Log probability of the refusal token; `-9999.0` for low probability.
+  Log probability for the refusal token; `-9999.0` for low-probability cases.
 - token `string`  
-  Text of a token in the refusal content.
+  Text of a token within the refusal content.
 - top_logprobs `array`  
-  List of the most likely candidate refusal tokens at this position.
+  Candidate refusal tokens most likely at this position.
   - bytes `array`  
-    UTF‑8 byte representation of a candidate refusal token.
+    UTF‑8 bytes for the candidate refusal token.
   - logprob `number`  
-    Log probability of the candidate refusal token.
+    Log probability for the candidate refusal token.
   - token `string`  
-    Text of a candidate refusal token.
+    Text of the candidate token.
 
 ---
 
@@ -957,15 +986,15 @@ A list of newly generated “refusal content tokens” in the current chunk.
 
 #### created `integer`
 
-Unix timestamp (seconds) when the chat completion was created. This value is the same across all chunks in the same stream.
+Unix timestamp (seconds) when the chat completion was created. The value is the same for all chunks in a stream.
 
 #### id `string`
 
-Unique identifier for the chat completion. All chunks in the same stream share the same `id`.
+Unique identifier of the chat completion. All chunks in the same stream share the same `id`.
 
 #### model `string`
 
-The model name used for this chat completion.
+Model name used for this completion.
 
 #### object `string`
 
@@ -973,42 +1002,42 @@ Object type. For streaming responses, this is always `chat.completion.chunk`.
 
 #### service_tier `string`
 
-Service type/tier used to process the request. Passed through if returned by the upstream model.
+The service tier/type used to process the request. Passed through if provided upstream.
 
 #### system_fingerprint `string`
 
-Fingerprint of the backend configuration used for this request. Although some upstreams mark it as deprecated, ZenMux still preserves and passes through this field.
+Fingerprint of the backend configuration used for this request. Although marked Deprecated by some upstream providers, ZenMux still preserves and passes through this field.
 
 ---
 
 ### usage `object` (included only in the final chunk)
 
-When `stream_options: {"include_usage": true}` is set in the request, the final chunk will include a `usage` object with the same structure as the non-streaming response.
+When `stream_options: {"include_usage": true}` is set, the final chunk includes the `usage` object; its structure is the same as the non-streaming response.
 
 - completion_tokens `integer`  
-  Number of completion tokens.
+  Number of tokens used in the completion.
 - prompt_tokens `integer`  
-  Number of prompt tokens.
+  Number of tokens used in the prompt.
 - total_tokens `integer`  
-  Total tokens used in the request.
+  Total tokens used in this request.
 
 - completion_tokens_details `object`  
-  Breakdown of completion tokens.
+  Completion token breakdown.
   - accepted_prediction_tokens `integer`  
-    Number of accepted predicted output tokens.
+    Number of predicted tokens accepted in the completion.
   - audio_tokens `integer`  
-    Number of audio-related tokens generated by the model.
+    Tokens related to model-generated audio.
   - reasoning_tokens `integer`  
-    Number of tokens used by the model for reasoning.
+    Tokens used by the model for reasoning.
   - rejected_prediction_tokens `integer`  
-    Number of predicted output tokens not used but still counted toward usage.
+    Number of predicted tokens not used but still counted toward usage.
 
 - prompt_tokens_details `object`  
-  Breakdown of prompt tokens.
+  Prompt token breakdown.
   - audio_tokens `integer`  
-    Number of audio input tokens in the prompt.
+    Audio input tokens in the prompt.
   - cached_tokens `integer`  
-    Number of cached tokens in the prompt.
+    Tokens matched via caching.
 
 ::: api-request POST /api/v1/chat/completions
 
@@ -1131,3 +1160,102 @@ curl https://zenmux.ai/api/v1/chat/completions \
 ```
 
 :::
+
+## Multi-turn tool-calling scenarios: pass back reasoning_details and signature
+
+When using Anthropic models such as Claude Opus 4.5 with `reasoning` enabled, in multi-turn tool-calling scenarios you **must pass back the previous turn’s `reasoning_details` (including the `signature` field) in full**, otherwise subsequent turns will not work properly.
+
+::: warning Important
+
+- **Background**: Claude Opus 4.5 natively uses the Anthropic Messages protocol, and Zenmux converts the Chat Completion protocol to the Messages protocol.
+- **Issue**: When reasoning is enabled, the second turn in a tool-calling conversation must include the reasoning `signature` to verify the integrity and continuity of the reasoning content.
+- **Solution**: Pass back the previous assistant message’s `reasoning` and `reasoning_details` fields in full.
+  :::
+
+### Request example
+
+```json
+{
+  "model": "anthropic/claude-sonnet-4.5",
+  "messages": [
+    {
+      "content": "今天是2025年8月15日，上海今天天气怎么样",
+      "role": "user"
+    },
+    {
+      "role": "assistant",
+      "tool_calls": [
+        {
+          "function": {
+            "name": "search_city_weather",
+            "arguments": "{\"city\":\"上海\"}"
+          },
+          "id": "toolu_bdrk_01S7xyqV3GYLJYrvBC5SwtPP",
+          "type": "function"
+        }
+      ],
+      "content": "",
+      "reasoning": "用户想知道2025年8月15日上海的天气情况。我需要使用search_city_weather函数来查询。\n\n参数：\n- city: \"上海\"\n- date: \"2025-08-15\"",
+      "reasoning_details": [
+        {
+          "type": "reasoning.text",
+          "text": "用户想知道2025年8月15日上海的天气情况。我需要使用search_city_weather函数来查询。\n\n参数：\n- city: \"上海\"\n- date: \"2025-08-15\"",
+          "signature": "EscCCkgICxABGAIqQF3ngnbIR+15nndalNEqnr7vq0v0Hyvle+twPh2SCMpMmNKf1oXiRPsjZG6Z46M69x06wks+4jm4N4FO3RH2mkgSDLChkfyKfk3ZndjatxoMi+H4ghd4hlGd+MRVIjBLKGRIcRwXS09pK50C2/ygvhnTlVMPkcARYG3nXV2ZWr2IPRHzY9XAK6QBJeVrmcsqrAGoL7TTMBUsMqMkfXlcRYABi+OPDht/9BOPKnV1k0RIWnnqzLfx4MQ/WSvTALBchQkYbXtO2v1nn5EhG/b9FZ+ZjUK0pAObWxv8aAIK47N1cTK+OB+iByPvlFb2vi0gX7xVOQXrmR5FLH03/JzmtqLpjgX/uYCYHddOvZzTx65STtajQ94FVKS35XkmHlbOIXqi4j1FIAioP4oqvDXqlZOMh8IKMJypT2I3vF2eGAE=",
+          "format": "anthropic-claude-v1",
+          "index": 0
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "toolu_bdrk_01S7xyqV3GYLJYrvBC5SwtPP",
+      "content": "{\"city\":\"上海市\",\"date\":\"2025-08-15\",\"week\":\"1\",\"dayweather\":\"多云\",\"nightweather\":\"多云\",\"daywind\":\"东南\",\"nightwind\":\"东南\",\"daypower\":\"1-3\",\"nightpower\":\"1-3\",\"daytemp_float\":\"35.0\",\"nighttemp_float\":\"28.0\"}"
+    }
+  ],
+  "stream": false,
+  "tools": [
+    {
+      "function": {
+        "name": "search_city_weather",
+        "description": "搜索城市天气",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "城市名称"
+            },
+            "date": {
+              "type": "string",
+              "description": "yyyy-mm-dd格式的日期"
+            }
+          },
+          "required": ["city", "date"],
+          "additionalProperties": false
+        }
+      },
+      "type": "function"
+    }
+  ],
+  "reasoning": {
+    "enabled": true
+  }
+}
+```
+
+### Key field notes
+
+| Field                             | Description                                                                 |
+| --------------------------------- | --------------------------------------------------------------------------- |
+| `reasoning`                       | Reasoning text in the assistant message; optionally passed back             |
+| `reasoning_details`               | **Must be passed back in full**, containing the detailed reasoning array    |
+| `reasoning_details[].signature`   | **Most critical field**; the reasoning signature credential; pass unchanged |
+| `reasoning_details[].format`      | Signature format identifier, e.g. `anthropic-claude-v1`                     |
+| `reasoning_details[].type`        | Reasoning content type, e.g. `reasoning.text`                               |
+
+### Workflow
+
+1. **First request**: The user asks a question; the model returns an assistant message containing `tool_calls`, as well as `reasoning` and `reasoning_details` (including `signature`)
+2. **Execute tools**: Your application executes the tool call and obtains the result
+3. **Second request**: Pass back the previous assistant message (**including `reasoning` and `reasoning_details`**) together with the tool execution result (tool message)
+4. **Model response**: The model generates the final answer based on the complete context


### PR DESCRIPTION
…invocation in chat completion API

- Introduced optional `reasoning` field to capture the assistant's reasoning process.
- Added `reasoning_details` array, required for multi-turn tool calls, containing detailed reasoning information including `signature` for context continuity.
- Updated documentation with examples and key field explanations for better clarity on usage.