### PR TITLE
docs: rename Moltbot to OpenClaw

### DIFF
--- a/docs_source/en/best-practices/openclaw.md
+++ b/docs_source/en/best-practices/openclaw.md
@@ -2,18 +2,18 @@
 head:
   - - meta
     - name: description
-      content: Guide to Using Moltbot with ZenMux
+      content: Guide to Using OpenClaw with ZenMux
   - - meta
     - name: keywords
-      content: Zenmux, best practices, integration, moltbot, OpenAI, API, messaging, gateway
+      content: Zenmux, best practices, integration, openclaw, moltbot, OpenAI, API, messaging, gateway
 ---
 
-# Guide to Using Moltbot with ZenMux
+# Guide to Using OpenClaw with ZenMux
 
-Moltbot is a powerful AI messaging gateway that connects multiple messaging platforms (WhatsApp, Telegram, Discord, Slack, Signal, iMessage, and more) to AI models. By integrating with ZenMux, you can access a wide range of models including GPT-5.2, Claude-4.5, Gemini-3, DeepSeek, and more.
+OpenClaw (formerly Moltbot, originally Clawdbot) is a powerful AI messaging gateway that connects multiple messaging platforms (WhatsApp, Telegram, Discord, Slack, Signal, iMessage, and more) to AI models. By integrating with ZenMux, you can access a wide range of models including GPT-5.2, Claude-4.5, Gemini-3, DeepSeek, and more.
 
 ::: info Compatibility Note
-ZenMux fully supports the OpenAI API protocol and can be used with Moltbot through simple configuration.
+ZenMux fully supports the OpenAI API protocol and can be used with OpenClaw through simple configuration.
 
 Note that the OpenAI protocol base_url is `https://zenmux.ai/api/v1`.
 :::
@@ -25,7 +25,7 @@ Note that the OpenAI protocol base_url is `https://zenmux.ai/api/v1`.
 
 ## Integration Methods
 
-There are two ways to use ZenMux with Moltbot:
+There are two ways to use ZenMux with OpenClaw:
 
 | Method | Best For | Complexity |
 | ------ | -------- | ---------- |
@@ -34,7 +34,7 @@ There are two ways to use ZenMux with Moltbot:
 
 ## Step 0: Get a ZenMux API Key
 
-Before configuring Moltbot, you need a ZenMux API Key. ZenMux offers two billing options:
+Before configuring OpenClaw, you need a ZenMux API Key. ZenMux offers two billing options:
 
 ::: code-group
 
@@ -70,14 +70,14 @@ https://docs.zenmux.ai/guide/pay-as-you-go
 
 ## Method 1: Use the ZenMux PR
 
-The easiest way to use ZenMux with Moltbot is to use the pending [ZenMux integration PR #3305](https://github.com/moltbot/moltbot/pull/3305), which provides full auto-discovery of ZenMux models.
+The easiest way to use ZenMux with OpenClaw is to use the pending [ZenMux integration PR #3305](https://github.com/openclaw/openclaw/pull/3305), which provides full auto-discovery of ZenMux models.
 
 ### Step 1: Clone and Checkout the PR
 
 ```bash
-# Clone the Moltbot repository
-git clone https://github.com/moltbot/moltbot.git
-cd moltbot
+# Clone the OpenClaw repository
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
 
 # Checkout PR #3305 (ZenMux integration)
 git fetch origin pull/3305/head:zenmux-integration
@@ -95,7 +95,7 @@ pnpm build
 Run the onboarding wizard and select ZenMux as your auth provider:
 
 ```bash
-pnpm moltbot onboard --auth-choice zenmux-api-key
+pnpm openclaw onboard --auth-choice zenmux-api-key
 ```
 
 Follow the prompts to enter your ZenMux API Key. The wizard will automatically:
@@ -108,7 +108,7 @@ Follow the prompts to enter your ZenMux API Key. The wizard will automatically:
 List the available models to verify the configuration:
 
 ```bash
-pnpm moltbot models list
+pnpm openclaw models list
 ```
 
 You should see ZenMux models listed with the `zenmux/` prefix, such as:
@@ -122,30 +122,30 @@ You should see ZenMux models listed with the `zenmux/` prefix, such as:
 Send a test message to verify everything works:
 
 ```bash
-pnpm moltbot agent --local --agent main --message "Hello, respond with just 'Hi!'"
+pnpm openclaw agent --local --agent main --message "Hello, respond with just 'Hi!'"
 ```
 
 ## Method 2: Manual Configuration
 
-If you prefer to use a stable release of Moltbot or want more control over the configuration, you can manually configure ZenMux as an explicit provider in your `moltbot.json` config file.
+If you prefer to use a stable release of OpenClaw or want more control over the configuration, you can manually configure ZenMux as an explicit provider in your `openclaw.json` config file.
 
-### Step 1: Install Moltbot
+### Step 1: Install OpenClaw
 
-Install Moltbot globally via npm:
+Install OpenClaw globally via npm:
 
 ```bash
-npm install -g moltbot
+npm install -g openclaw@latest
 ```
 
-Or run the onboarding wizard to set up Moltbot:
+Or run the onboarding wizard to set up OpenClaw:
 
 ```bash
-moltbot onboard
+openclaw onboard --install-daemon
 ```
 
 ### Step 2: Configure ZenMux Provider
 
-Add the ZenMux provider configuration to your `~/.clawdbot/moltbot.json` (or `~/.moltbot/moltbot.json`) file:
+Add the ZenMux provider configuration to your `~/.openclaw/openclaw.json` file:
 
 ```json
 {
@@ -238,7 +238,7 @@ Each model definition requires:
 List the available models:
 
 ```bash
-moltbot models list
+openclaw models list
 ```
 
 You should see your configured ZenMux models:
@@ -256,7 +256,7 @@ zenmux/anthropic/claude-sonnet-4.5         text+image 195k     no    yes   confi
 Set your preferred default model:
 
 ```bash
-moltbot models set zenmux/openai/gpt-5.2
+openclaw models set zenmux/openai/gpt-5.2
 ```
 
 ## Using ZenMux Models
@@ -267,7 +267,7 @@ Once configured, you can use ZenMux models in various ways:
 
 ```bash
 # Run a quick agent command
-moltbot agent --local --agent main --message "Explain quantum computing in simple terms"
+openclaw agent --local --agent main --message "Explain quantum computing in simple terms"
 ```
 
 ### Via Messaging Channels
@@ -276,10 +276,10 @@ Configure your messaging channels (WhatsApp, Telegram, Discord, etc.) and the ga
 
 ```bash
 # Start the gateway
-moltbot gateway run
+openclaw gateway run
 
 # Check channel status
-moltbot channels status
+openclaw channels status
 ```
 
 ### Switching Models
@@ -288,10 +288,10 @@ You can switch models at any time:
 
 ```bash
 # Set a different default model
-moltbot models set zenmux/anthropic/claude-sonnet-4.5
+openclaw models set zenmux/anthropic/claude-sonnet-4.5
 
 # Or specify a model inline (Method 1 only)
-moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --message "Hello"
+openclaw agent --local --agent main --model zenmux/deepseek/deepseek-chat --message "Hello"
 ```
 
 ## Troubleshooting
@@ -318,7 +318,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 :::
 
 ::: details Model Not Found
-**Issue**: Moltbot reports that the model cannot be found
+**Issue**: OpenClaw reports that the model cannot be found
 
 **Solutions**:
 
@@ -333,7 +333,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 :::
 
 ::: details Connection Failure
-**Issue**: Moltbot cannot connect to ZenMux
+**Issue**: OpenClaw cannot connect to ZenMux
 
 **Solutions**:
 
@@ -350,7 +350,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 
 1. Kill any running gateway process:
    ```bash
-   pkill -9 -f moltbot-gateway
+   pkill -9 -f openclaw-gateway
    ```
 
 2. Rebuild the project (if using Method 1):
@@ -360,13 +360,13 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 
 3. List models again:
    ```bash
-   moltbot models list
+   openclaw models list
    ```
 :::
 
 ## Supported Models
 
-ZenMux provides access to a wide range of models. Here are some popular options for Moltbot:
+ZenMux provides access to a wide range of models. Here are some popular options for OpenClaw:
 
 | Model | ID | Best For |
 | ----- | -- | -------- |

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -113,7 +113,7 @@ export default defineLoacaleConfig({
           { text: "Dify Integration", link: "/best-practices/dify" },
           { text: "Neovate Integration", link: "/best-practices/neovate-code" },
           { text: "Github Copilot", link: "/best-practices/github-copilot" },
-          { text: "Moltbot", link: "/best-practices/moltbot" },
+          { text: "OpenClaw", link: "/best-practices/openclaw" },
         ],
       },
       {

--- a/docs_source/zh/best-practices/openclaw.md
+++ b/docs_source/zh/best-practices/openclaw.md
@@ -2,18 +2,18 @@
 head:
   - - meta
     - name: description
-      content: Moltbot 接入 ZenMux 使用指南
+      content: OpenClaw 接入 ZenMux 使用指南
   - - meta
     - name: keywords
-      content: Zenmux, 最佳实践, 集成, moltbot, OpenAI, API, 消息网关
+      content: Zenmux, 最佳实践, 集成, openclaw, moltbot, OpenAI, API, 消息网关
 ---
 
-# Moltbot 接入 ZenMux 使用指南
+# OpenClaw 接入 ZenMux 使用指南
 
-Moltbot 是一个强大的 AI 消息网关，可以将多个消息平台（WhatsApp、Telegram、Discord、Slack、Signal、iMessage 等）连接到 AI 模型。通过接入 ZenMux，您可以使用包括 GPT-5.2、Claude-4.5、Gemini-3、DeepSeek 等在内的多种模型。
+OpenClaw（原名 Moltbot，最初名为 Clawdbot）是一个强大的 AI 消息网关，可以将多个消息平台（WhatsApp、Telegram、Discord、Slack、Signal、iMessage 等）连接到 AI 模型。通过接入 ZenMux，您可以使用包括 GPT-5.2、Claude-4.5、Gemini-3、DeepSeek 等在内的多种模型。
 
 ::: info 兼容性说明
-ZenMux 完全支持 OpenAI API 协议，可以通过简单配置与 Moltbot 配合使用。
+ZenMux 完全支持 OpenAI API 协议，可以通过简单配置与 OpenClaw 配合使用。
 
 注意 OpenAI 协议的 base_url 为 `https://zenmux.ai/api/v1`。
 :::
@@ -25,7 +25,7 @@ ZenMux 完全支持 OpenAI API 协议，可以通过简单配置与 Moltbot 配�
 
 ## 接入方式
 
-有两种方式将 ZenMux 与 Moltbot 配合使用：
+有两种方式将 ZenMux 与 OpenClaw 配合使用：
 
 | 方式 | 适用场景 | 复杂度 |
 | ---- | -------- | ------ |
@@ -34,7 +34,7 @@ ZenMux 完全支持 OpenAI API 协议，可以通过简单配置与 Moltbot 配�
 
 ## 第 0 步：获取 ZenMux API Key
 
-在配置 Moltbot 之前，您需要一个 ZenMux API Key。ZenMux 提供两种计费方式：
+在配置 OpenClaw 之前，您需要一个 ZenMux API Key。ZenMux 提供两种计费方式：
 
 ::: code-group
 
@@ -70,14 +70,14 @@ https://docs.zenmux.ai/zh/guide/pay-as-you-go
 
 ## 方式一：使用 ZenMux PR
 
-使用 ZenMux 与 Moltbot 最简单的方式是使用待合并的 [ZenMux 集成 PR #3305](https://github.com/moltbot/moltbot/pull/3305)，它提供了完整的 ZenMux 模型自动发现功能。
+使用 ZenMux 与 OpenClaw 最简单的方式是使用待合并的 [ZenMux 集成 PR #3305](https://github.com/openclaw/openclaw/pull/3305)，它提供了完整的 ZenMux 模型自动发现功能。
 
 ### 第 1 步：克隆并切换到 PR 分支
 
 ```bash
-# 克隆 Moltbot 仓库
-git clone https://github.com/moltbot/moltbot.git
-cd moltbot
+# 克隆 OpenClaw 仓库
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
 
 # 切换到 PR #3305（ZenMux 集成）
 git fetch origin pull/3305/head:zenmux-integration
@@ -95,7 +95,7 @@ pnpm build
 运行引导向导并选择 ZenMux 作为认证提供商：
 
 ```bash
-pnpm moltbot onboard --auth-choice zenmux-api-key
+pnpm openclaw onboard --auth-choice zenmux-api-key
 ```
 
 按照提示输入您的 ZenMux API Key。向导将自动：
@@ -108,7 +108,7 @@ pnpm moltbot onboard --auth-choice zenmux-api-key
 列出可用模型以验证配置：
 
 ```bash
-pnpm moltbot models list
+pnpm openclaw models list
 ```
 
 您应该看到带有 `zenmux/` 前缀的 ZenMux 模型，例如：
@@ -122,30 +122,30 @@ pnpm moltbot models list
 发送测试消息以验证一切正常：
 
 ```bash
-pnpm moltbot agent --local --agent main --message "你好，请只回复'嗨！'"
+pnpm openclaw agent --local --agent main --message "你好，请只回复'嗨！'"
 ```
 
 ## 方式二：手动配置
 
-如果您希望使用 Moltbot 的稳定版本或需要更多配置控制，可以在 `moltbot.json` 配置文件中手动将 ZenMux 配置为显式提供商。
+如果您希望使用 OpenClaw 的稳定版本或需要更多配置控制，可以在 `openclaw.json` 配置文件中手动将 ZenMux 配置为显式提供商。
 
-### 第 1 步：安装 Moltbot
+### 第 1 步：安装 OpenClaw
 
-通过 npm 全局安装 Moltbot：
+通过 npm 全局安装 OpenClaw：
 
 ```bash
-npm install -g moltbot
+npm install -g openclaw@latest
 ```
 
-或运行引导向导设置 Moltbot：
+或运行引导向导设置 OpenClaw：
 
 ```bash
-moltbot onboard
+openclaw onboard --install-daemon
 ```
 
 ### 第 2 步：配置 ZenMux 提供商
 
-将 ZenMux 提供商配置添加到您的 `~/.clawdbot/moltbot.json`（或 `~/.moltbot/moltbot.json`）文件：
+将 ZenMux 提供商配置添加到您的 `~/.openclaw/openclaw.json` 文件：
 
 ```json
 {
@@ -238,7 +238,7 @@ moltbot onboard
 列出可用模型：
 
 ```bash
-moltbot models list
+openclaw models list
 ```
 
 您应该看到已配置的 ZenMux 模型：
@@ -256,7 +256,7 @@ zenmux/anthropic/claude-sonnet-4.5         text+image 195k     no    yes   confi
 设置您偏好的默认模型：
 
 ```bash
-moltbot models set zenmux/openai/gpt-5.2
+openclaw models set zenmux/openai/gpt-5.2
 ```
 
 ## 使用 ZenMux 模型
@@ -267,7 +267,7 @@ moltbot models set zenmux/openai/gpt-5.2
 
 ```bash
 # 运行快速 agent 命令
-moltbot agent --local --agent main --message "用简单的话解释量子计算"
+openclaw agent --local --agent main --message "用简单的话解释量子计算"
 ```
 
 ### 通过消息通道
@@ -276,10 +276,10 @@ moltbot agent --local --agent main --message "用简单的话解释量子计算"
 
 ```bash
 # 启动网关
-moltbot gateway run
+openclaw gateway run
 
 # 检查通道状态
-moltbot channels status
+openclaw channels status
 ```
 
 ### 切换模型
@@ -288,10 +288,10 @@ moltbot channels status
 
 ```bash
 # 设置不同的默认模型
-moltbot models set zenmux/anthropic/claude-sonnet-4.5
+openclaw models set zenmux/anthropic/claude-sonnet-4.5
 
 # 或在命令中指定模型（仅方式一）
-moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --message "你好"
+openclaw agent --local --agent main --model zenmux/deepseek/deepseek-chat --message "你好"
 ```
 
 ## 故障排除
@@ -318,7 +318,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 :::
 
 ::: details 模型未找到
-**问题**：Moltbot 报告找不到模型
+**问题**：OpenClaw 报告找不到模型
 
 **解决方案**：
 
@@ -333,7 +333,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 :::
 
 ::: details 连接失败
-**问题**：Moltbot 无法连接到 ZenMux
+**问题**：OpenClaw 无法连接到 ZenMux
 
 **解决方案**：
 
@@ -350,7 +350,7 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 
 1. 终止运行中的网关进程：
    ```bash
-   pkill -9 -f moltbot-gateway
+   pkill -9 -f openclaw-gateway
    ```
 
 2. 重新构建项目（如果使用方式一）：
@@ -360,13 +360,13 @@ moltbot agent --local --agent main --model zenmux/deepseek/deepseek-chat --messa
 
 3. 再次列出模型：
    ```bash
-   moltbot models list
+   openclaw models list
    ```
 :::
 
 ## 支持的模型
 
-ZenMux 提供多种模型供选择。以下是 Moltbot 的一些热门选项：
+ZenMux 提供多种模型供选择。以下是 OpenClaw 的一些热门选项：
 
 | 模型 | ID | 最佳用途 |
 | ---- | -- | -------- |

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -126,8 +126,8 @@ export default defineLoacaleConfig({
             link: "/zh/best-practices/github-copilot",
           },
           {
-            text: "Moltbot 接入 ZenMux 指南",
-            link: "/zh/best-practices/moltbot",
+            text: "OpenClaw 接入 ZenMux 指南",
+            link: "/zh/best-practices/openclaw",
           },
         ],
       },


### PR DESCRIPTION
Moltbot has been renamed to OpenClaw (naming history: Clawdbot → Moltbot → OpenClaw). Updated all documentation to reflect:

- Product name and references
- GitHub repo: openclaw/openclaw
- npm package: openclaw@latest
- CLI commands: openclaw
- Config path: ~/.openclaw/openclaw.json