### PR TITLE
fix: update vertex-ai api endpoint to include /v1

### DIFF
--- a/docs_source/.vitepress/theme/endpoint-drawer.vue
+++ b/docs_source/.vitepress/theme/endpoint-drawer.vue
@@ -86,7 +86,7 @@ const providersData: Provider[] = [
   {
     name: "Google Vertex AI",
     subtitle: "Vertex AI Compatible",
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     iconType: "google",
     supportedModels: {
       iconList: [

--- a/docs_source/en/api/vertexai/generate-content-old.md
+++ b/docs_source/en/api/vertexai/generate-content-old.md
@@ -39,7 +39,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -57,7 +57,7 @@ const client = new genai.GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });

--- a/docs_source/en/api/vertexai/generate-content.md
+++ b/docs_source/en/api/vertexai/generate-content.md
@@ -1050,7 +1050,7 @@ const client = GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });
@@ -1071,7 +1071,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/en/best-practices/cc-switch.md
+++ b/docs_source/en/best-practices/cc-switch.md
@@ -224,13 +224,13 @@ Copy and paste the configuration above into Codex’s config file, then save to 
 | Setting           | Value                             | Notes                                |
 | ----------------- | --------------------------------- | ------------------------------------ |
 | **Provider Name** | `ZenMux`                          | Custom name for easy identity        |
-| **Base URL**      | `https://zenmux.ai/api/vertex-ai` | ZenMux Vertex AI-compatible endpoint |
+| **Base URL**      | `https://zenmux.ai/api/vertex-ai/v1` | ZenMux Vertex AI-compatible endpoint |
 | **API Key**       | `sk-ss-v1-xxx` or `sk-ai-v1-xxx`  | Your ZenMux API key                  |
 
 ##### Environment Variable Example (Copy & Paste)
 
 ```env
-GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai
+GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai/v1
 GEMINI_API_KEY=<ZENMUX_API_KEY>
 GEMINI_MODEL=google/gemini-3-flash-preview
 ```
@@ -243,7 +243,7 @@ Copy and paste the configuration above into Gemini CLI’s config file, then sav
 | Setting           | Value                             | Notes                                |
 | ----------------- | --------------------------------- | ------------------------------------ |
 | **Provider Name** | `ZenMux`                          | Custom name for easy identity        |
-| **Base URL**      | `https://zenmux.ai/api/vertex-ai` | ZenMux Vertex AI-compatible endpoint |
+| **Base URL**      | `https://zenmux.ai/api/vertex-ai/v1` | ZenMux Vertex AI-compatible endpoint |
 | **API Key**       | `sk-ss-v1-xxx` or `sk-ai-v1-xxx`  | Your ZenMux API key                  |
 
 ##### JSON Config Example (Copy & Paste)

--- a/docs_source/en/best-practices/gemini-cli.md
+++ b/docs_source/en/best-practices/gemini-cli.md
@@ -88,7 +88,7 @@ You can configure environment variables in `~/.gemini/.env`. Gemini CLI will aut
 ```env
 GEMINI_API_KEY=sk-ss-v1-xxx  # [!code highlight]
 GEMINI_MODEL=google/gemini-2.5-pro  # [!code highlight]
-GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai  # [!code highlight]
+GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai/v1  # [!code highlight]
 ```
 
 Alternatively, set them in your shell profile:
@@ -99,14 +99,14 @@ Alternatively, set them in your shell profile:
 # Edit ~/.zshrc or ~/.bashrc
 export GEMINI_API_KEY="sk-ss-v1-xxx"  # [!code highlight]
 export GEMINI_MODEL="google/gemini-2.5-pro"  # [!code highlight]
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"  # [!code highlight]
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"  # [!code highlight]
 ```
 
 ```powershell [Windows PowerShell]
 # Edit your PowerShell profile
 $env:GEMINI_API_KEY = "sk-ss-v1-xxx"  # [!code highlight]
 $env:GEMINI_MODEL = "google/gemini-2.5-pro"  # [!code highlight]
-$env:GOOGLE_GEMINI_BASE_URL = "https://zenmux.ai/api/vertex-ai"  # [!code highlight]
+$env:GOOGLE_GEMINI_BASE_URL = "https://zenmux.ai/api/vertex-ai/v1"  # [!code highlight]
 
 # To make it persistent, add it to your PowerShell profile:
 # notepad $PROFILE
@@ -383,9 +383,9 @@ When the model tries to use built-in tools (such as Google Search), you may see 
 **Solution**:
 
 - Check your network connection
-- Verify the Base URL is set to `https://zenmux.ai/api/vertex-ai`
+- Verify the Base URL is set to `https://zenmux.ai/api/vertex-ai/v1`
 - Check whether firewall settings are blocking outbound connections
-- Try `curl https://zenmux.ai/api/vertex-ai/models` to test connectivity
+- Try `curl https://zenmux.ai/api/vertex-ai/v1/models` to test connectivity
   :::
 
 ::: details .env file not taking effect
@@ -510,21 +510,21 @@ Session history is stored in `~/.gemini/history/`. Adjust `maxAge` as needed, or
 ```bash [Daily Development]
 # Balance performance and cost
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-pro"
 ```
 
 ```bash [Code Review]
 # Prioritize reasoning capability
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-pro"
 ```
 
 ```bash [Rapid Iteration]
 # Prioritize response speed
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-flash"
 ```
 

--- a/docs_source/en/guide/advanced/image-generation.md
+++ b/docs_source/en/guide/advanced/image-generation.md
@@ -49,7 +49,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -83,7 +83,7 @@ const client = new genai.GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",  // Replace with your API key
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1"
   }
 });
@@ -110,7 +110,7 @@ console.log(response);
 
 - **api_key**: Your ZenMux API key
 - **vertexai**: Must be set to `true` to enable the Vertex AI protocol
-- **base_url**: ZenMux Vertex AI endpoint `https://zenmux.ai/api/vertex-ai`
+- **base_url**: ZenMux Vertex AI endpoint `https://zenmux.ai/api/vertex-ai/v1`
 - **responseModalities**: Response modalities; image generation must include `["TEXT", "IMAGE"]`
 
 ### Invocation Modes

--- a/docs_source/en/guide/advanced/multimodal.md
+++ b/docs_source/en/guide/advanced/multimodal.md
@@ -1511,7 +1511,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -1537,7 +1537,7 @@ const client = new GoogleGenAI({
   apiKey: "<your ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });
@@ -1603,7 +1603,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -1675,7 +1675,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -1731,7 +1731,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/en/guide/advanced/reasoning.md
+++ b/docs_source/en/guide/advanced/reasoning.md
@@ -618,7 +618,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -644,7 +644,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -668,7 +668,7 @@ const client = new GoogleGenAI({
   apiKey: "<your ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });

--- a/docs_source/en/guide/advanced/structured-output.md
+++ b/docs_source/en/guide/advanced/structured-output.md
@@ -808,7 +808,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -853,7 +853,7 @@ const client = new GoogleGenAI({
   apiKey: "<your ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });
@@ -910,7 +910,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/en/guide/advanced/tool-calls.md
+++ b/docs_source/en/guide/advanced/tool-calls.md
@@ -1435,7 +1435,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -1512,7 +1512,7 @@ const client = new GoogleGenAI({
   apiKey: "<your ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });

--- a/docs_source/en/guide/advanced/video-generation.md
+++ b/docs_source/en/guide/advanced/video-generation.md
@@ -44,7 +44,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -74,7 +74,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -104,7 +104,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -142,7 +142,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -177,7 +177,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -212,7 +212,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -252,7 +252,7 @@ for video in operation.response.generated_videos:
 
 - **api_key**: Your ZenMux API key
 - **vertexai**: Must be set to `true` to enable the Vertex AI protocol
-- **base_url**: ZenMux Vertex AI endpoint `https://zenmux.ai/api/vertex-ai`
+- **base_url**: ZenMux Vertex AI endpoint `https://zenmux.ai/api/vertex-ai/v1`
 - **model**: The video generation model name, such as `google/veo-3.1-generate-001`
 - **prompt**: A text prompt describing the video content to generate
 

--- a/docs_source/en/guide/advanced/web-search.md
+++ b/docs_source/en/guide/advanced/web-search.md
@@ -640,7 +640,7 @@ const client = new GoogleGenAI({
   apiKey: "YOUR_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });
@@ -717,7 +717,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/en/guide/quickstart.md
+++ b/docs_source/en/guide/quickstart.md
@@ -104,7 +104,7 @@ ZenMux supports four major API protocols, letting you use your preferred SDK to 
 | **OpenAI Chat Completions** | `https://zenmux.ai/api/v1` | OpenAI SDK | The most widely used Chat API |
 | **OpenAI Responses** | `https://zenmux.ai/api/v1` | OpenAI SDK | OpenAI's next-gen Responses API |
 | **Anthropic Messages** | `https://zenmux.ai/api/anthropic` | Anthropic SDK | Native protocol for the Claude family |
-| **Google Gemini** | `https://zenmux.ai/api/vertex-ai` | Google GenAI SDK | Native protocol for the Gemini family |
+| **Google Gemini** | `https://zenmux.ai/api/vertex-ai/v1` | Google GenAI SDK | Native protocol for the Gemini family |
 
 ::: tip 💡 Cross-Protocol Calling
 One of ZenMux's core strengths is **protocol agnosticism** — you can call any model through any supported protocol. For example, use the OpenAI SDK to call Claude models, or the Anthropic SDK to call Gemini models.
@@ -353,7 +353,7 @@ curl https://zenmux.ai/api/anthropic/v1/messages \
 ::: info Compatibility
 ZenMux supports the Google Gemini (Vertex AI) protocol, allowing you to call models directly with the Google GenAI SDK.
 
-The base URL is `https://zenmux.ai/api/vertex-ai`. You need to set `vertexai=True` and configure custom `http_options`.
+The base URL is `https://zenmux.ai/api/vertex-ai/v1`. You need to set `vertexai=True` and configure custom `http_options`.
 :::
 
 ::: code-group
@@ -370,7 +370,7 @@ client = genai.Client(
     # 3. Point the base URL to the ZenMux endpoint
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     )
 )
 
@@ -394,7 +394,7 @@ const ai = new GoogleGenAI({
   // 3. Point the base URL to the ZenMux endpoint
   httpOptions: {
     apiVersion: "v1",
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
   },
 });
 

--- a/docs_source/zh/api/vertexai/generate-content-old.md
+++ b/docs_source/zh/api/vertexai/generate-content-old.md
@@ -32,7 +32,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -50,7 +50,7 @@ const client = new genai.GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });

--- a/docs_source/zh/api/vertexai/generate-content.md
+++ b/docs_source/zh/api/vertexai/generate-content.md
@@ -1050,7 +1050,7 @@ const client = GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });
@@ -1071,7 +1071,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/zh/best-practices/cc-switch.md
+++ b/docs_source/zh/best-practices/cc-switch.md
@@ -224,13 +224,13 @@ wire_api = "responses"
 | 配置项            | 值                                | 说明                      |
 | ----------------- | --------------------------------- | ------------------------- |
 | **Provider Name** | `ZenMux`                          | 自定义名称，便于识别      |
-| **Base URL**      | `https://zenmux.ai/api/vertex-ai` | ZenMux Vertex AI 兼容端点 |
+| **Base URL**      | `https://zenmux.ai/api/vertex-ai/v1` | ZenMux Vertex AI 兼容端点 |
 | **API Key**       | `sk-ss-v1-xxx` 或 `sk-ai-v1-xxx`  | 您的 ZenMux API Key       |
 
 ##### 配置环境变量示例（可直接复制）
 
 ```env
-GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai
+GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai/v1
 GEMINI_API_KEY=<ZENMUX_API_KEY>
 GEMINI_MODEL=google/gemini-3-flash-preview
 ```
@@ -243,7 +243,7 @@ GEMINI_MODEL=google/gemini-3-flash-preview
 | 配置项            | 值                                | 说明                      |
 | ----------------- | --------------------------------- | ------------------------- |
 | **Provider Name** | `ZenMux`                          | 自定义名称，便于识别      |
-| **Base URL**      | `https://zenmux.ai/api/vertex-ai` | ZenMux Vertex AI 兼容端点 |
+| **Base URL**      | `https://zenmux.ai/api/vertex-ai/v1` | ZenMux Vertex AI 兼容端点 |
 | **API Key**       | `sk-ss-v1-xxx` 或 `sk-ai-v1-xxx`  | 您的 ZenMux API Key       |
 
 ##### 配置JSON示例（可直接复制）

--- a/docs_source/zh/best-practices/gemini-cli.md
+++ b/docs_source/zh/best-practices/gemini-cli.md
@@ -88,7 +88,7 @@ mkdir -p ~/.gemini
 ```env
 GEMINI_API_KEY=sk-ss-v1-xxx  # [!code highlight]
 GEMINI_MODEL=google/gemini-2.5-pro  # [!code highlight]
-GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai  # [!code highlight]
+GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai/v1  # [!code highlight]
 ```
 
 也可以在 shell 配置文件中设置：
@@ -99,14 +99,14 @@ GOOGLE_GEMINI_BASE_URL=https://zenmux.ai/api/vertex-ai  # [!code highlight]
 # 编辑 ~/.zshrc 或 ~/.bashrc 文件
 export GEMINI_API_KEY="sk-ss-v1-xxx"  # [!code highlight]
 export GEMINI_MODEL="google/gemini-2.5-pro"  # [!code highlight]
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"  # [!code highlight]
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"  # [!code highlight]
 ```
 
 ```powershell [Windows PowerShell]
 # 编辑 PowerShell 配置文件
 $env:GEMINI_API_KEY = "sk-ss-v1-xxx"  # [!code highlight]
 $env:GEMINI_MODEL = "google/gemini-2.5-pro"  # [!code highlight]
-$env:GOOGLE_GEMINI_BASE_URL = "https://zenmux.ai/api/vertex-ai"  # [!code highlight]
+$env:GOOGLE_GEMINI_BASE_URL = "https://zenmux.ai/api/vertex-ai/v1"  # [!code highlight]
 
 # 若需永久生效，请添加到 PowerShell 配置文件中：
 # notepad $PROFILE
@@ -384,9 +384,9 @@ export GEMINI_MODEL="google/gemini-2.5-pro"  # [!code highlight]
 **解决方案**：
 
 - 检查网络连接是否正常
-- 验证 Base URL 是否配置正确为 `https://zenmux.ai/api/vertex-ai`
+- 验证 Base URL 是否配置正确为 `https://zenmux.ai/api/vertex-ai/v1`
 - 确认防火墙设置是否阻止了外部连接
-- 尝试使用 `curl https://zenmux.ai/api/vertex-ai/models` 测试连接
+- 尝试使用 `curl https://zenmux.ai/api/vertex-ai/v1/models` 测试连接
   :::
 
 ::: details .env 配置文件不生效
@@ -511,21 +511,21 @@ Gemini CLI 支持会话历史保留，方便回顾之前的对话：
 ```bash [日常开发]
 # 平衡性能和成本
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-pro"
 ```
 
 ```bash [代码审查]
 # 注重推理能力
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-pro"
 ```
 
 ```bash [快速迭代]
 # 注重响应速度
 export GEMINI_API_KEY="sk-ss-v1-xxx"
-export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai"
+export GOOGLE_GEMINI_BASE_URL="https://zenmux.ai/api/vertex-ai/v1"
 export GEMINI_MODEL="google/gemini-2.5-flash"
 ```
 

--- a/docs_source/zh/guide/advanced/image-generation.md
+++ b/docs_source/zh/guide/advanced/image-generation.md
@@ -49,7 +49,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -83,7 +83,7 @@ const client = new genai.GoogleGenAI({
   apiKey: "$ZENMUX_API_KEY",  // 替换为你的 API Key
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1"
   }
 });
@@ -110,7 +110,7 @@ console.log(response);
 
 - **api_key**: 你的 ZenMux API 密钥
 - **vertexai**: 必须设置为 `true` 以启用 Vertex AI 协议
-- **base_url**: ZenMux Vertex AI 端点 `https://zenmux.ai/api/vertex-ai`
+- **base_url**: ZenMux Vertex AI 端点 `https://zenmux.ai/api/vertex-ai/v1`
 - **responseModalities**: 响应模态,图片生成必须包含 `["TEXT", "IMAGE"]`
 
 ### 调用模式

--- a/docs_source/zh/guide/advanced/multimodal.md
+++ b/docs_source/zh/guide/advanced/multimodal.md
@@ -1511,7 +1511,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -1537,7 +1537,7 @@ const client = new GoogleGenAI({
   apiKey: "<你的 ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });
@@ -1603,7 +1603,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -1675,7 +1675,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 
@@ -1731,7 +1731,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/zh/guide/advanced/reasoning.md
+++ b/docs_source/zh/guide/advanced/reasoning.md
@@ -618,7 +618,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -644,7 +644,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -668,7 +668,7 @@ const client = new GoogleGenAI({
   apiKey: "<你的 ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });

--- a/docs_source/zh/guide/advanced/structured-output.md
+++ b/docs_source/zh/guide/advanced/structured-output.md
@@ -808,7 +808,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -853,7 +853,7 @@ const client = new GoogleGenAI({
   apiKey: "<你的 ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });
@@ -910,7 +910,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/zh/guide/advanced/tool-calls.md
+++ b/docs_source/zh/guide/advanced/tool-calls.md
@@ -1435,7 +1435,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     ),
 )
 
@@ -1512,7 +1512,7 @@ const client = new GoogleGenAI({
   apiKey: "<你的 ZENMUX_API_KEY>", // [!code highlight]
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
     apiVersion: "v1",
   },
 });

--- a/docs_source/zh/guide/advanced/video-generation.md
+++ b/docs_source/zh/guide/advanced/video-generation.md
@@ -44,7 +44,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -74,7 +74,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -104,7 +104,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -142,7 +142,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -177,7 +177,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -212,7 +212,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version="v1",
-        base_url="https://zenmux.ai/api/vertex-ai"
+        base_url="https://zenmux.ai/api/vertex-ai/v1"
     )
 )
 
@@ -252,7 +252,7 @@ for video in operation.response.generated_videos:
 
 - **api_key**: 你的 ZenMux API 密钥
 - **vertexai**: 必须设置为 `true` 以启用 Vertex AI 协议
-- **base_url**: ZenMux Vertex AI 端点 `https://zenmux.ai/api/vertex-ai`
+- **base_url**: ZenMux Vertex AI 端点 `https://zenmux.ai/api/vertex-ai/v1`
 - **model**: 视频生成模型名称，如 `google/veo-3.1-generate-001`
 - **prompt**: 描述要生成的视频内容的文本提示词
 

--- a/docs_source/zh/guide/advanced/web-search.md
+++ b/docs_source/zh/guide/advanced/web-search.md
@@ -639,7 +639,7 @@ const client = new GoogleGenAI({
   apiKey: "YOUR_API_KEY",
   vertexai: true,
   httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1",
     apiVersion: "v1",
   },
 });
@@ -716,7 +716,7 @@ client = genai.Client(
     vertexai=True,
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai'
+        base_url='https://zenmux.ai/api/vertex-ai/v1'
     ),
 )
 

--- a/docs_source/zh/guide/quickstart.md
+++ b/docs_source/zh/guide/quickstart.md
@@ -104,7 +104,7 @@ ZenMux 支持四种主流 API 协议，你可以使用最熟悉的 SDK 调用 Ze
 | **OpenAI Chat Completions** | `https://zenmux.ai/api/v1` | OpenAI SDK | 最广泛使用的 Chat API |
 | **OpenAI Responses** | `https://zenmux.ai/api/v1` | OpenAI SDK | OpenAI 新一代 Responses API |
 | **Anthropic Messages** | `https://zenmux.ai/api/anthropic` | Anthropic SDK | Claude 系列原生协议 |
-| **Google Gemini** | `https://zenmux.ai/api/vertex-ai` | Google GenAI SDK | Gemini 系列原生协议 |
+| **Google Gemini** | `https://zenmux.ai/api/vertex-ai/v1` | Google GenAI SDK | Gemini 系列原生协议 |
 
 ::: tip 💡 跨协议调用
 ZenMux 的核心优势之一是**协议无关性**——你可以通过任意支持的协议调用任意模型。例如，用 OpenAI SDK 调用 Claude 模型，或用 Anthropic SDK 调用 Gemini 模型。
@@ -353,7 +353,7 @@ curl https://zenmux.ai/api/anthropic/v1/messages \
 ::: info 兼容性说明
 ZenMux 支持 Google Gemini（Vertex AI）协议，可以使用 Google GenAI SDK 直接调用。
 
-Base URL 为 `https://zenmux.ai/api/vertex-ai`，需要设置 `vertexai=True` 和自定义 `http_options`。
+Base URL 为 `https://zenmux.ai/api/vertex-ai/v1`，需要设置 `vertexai=True` 和自定义 `http_options`。
 :::
 
 ::: code-group
@@ -370,7 +370,7 @@ client = genai.Client(
     # 3. 将 base_url 指向 ZenMux 端点
     http_options=types.HttpOptions(
         api_version='v1',
-        base_url='https://zenmux.ai/api/vertex-ai' # [!code highlight]
+        base_url='https://zenmux.ai/api/vertex-ai/v1' # [!code highlight]
     )
 )
 
@@ -394,7 +394,7 @@ const ai = new GoogleGenAI({
   // 3. 将 base_url 指向 ZenMux 端点
   httpOptions: {
     apiVersion: "v1",
-    baseUrl: "https://zenmux.ai/api/vertex-ai", // [!code highlight]
+    baseUrl: "https://zenmux.ai/api/vertex-ai/v1", // [!code highlight]
   },
 });
 

--- a/scripts/test-reasoning.py
+++ b/scripts/test-reasoning.py
@@ -270,7 +270,7 @@ def test_vertex_ai_thinking():
             vertexai=True,
             http_options=types.HttpOptions(
                 api_version='v1',
-                base_url='https://zenmux.ai/api/vertex-ai'
+                base_url='https://zenmux.ai/api/vertex-ai/v1'
             ),
         )
         

--- a/scripts/test-structured-output.py
+++ b/scripts/test-structured-output.py
@@ -324,7 +324,7 @@ def test_vertex_ai():
             vertexai=True,
             http_options=types.HttpOptions(
                 api_version='v1',
-                base_url='https://zenmux.ai/api/vertex-ai'
+                base_url='https://zenmux.ai/api/vertex-ai/v1'
             ),
         )
         

--- a/scripts/test-tool-calls-response-format.py
+++ b/scripts/test-tool-calls-response-format.py
@@ -270,7 +270,7 @@ def test_vertex_ai_response_format():
             vertexai=True,
             http_options=types.HttpOptions(
                 api_version='v1',
-                base_url='https://zenmux.ai/api/vertex-ai'
+                base_url='https://zenmux.ai/api/vertex-ai/v1'
             ),
         )
         

--- a/scripts/test-tool-calls.py
+++ b/scripts/test-tool-calls.py
@@ -416,7 +416,7 @@ def test_vertex_ai_tools():
             vertexai=True,
             http_options=types.HttpOptions(
                 api_version='v1',
-                base_url='https://zenmux.ai/api/vertex-ai'
+                base_url='https://zenmux.ai/api/vertex-ai/v1'
             ),
         )
         


### PR DESCRIPTION
The previous endpoint `https://zenmux.ai/api/vertex-ai` returns an HTML page (React frontend) instead of JSON. This PR updates all documentation and script references to use the correct `https://zenmux.ai/api/vertex-ai/v1` endpoint.

Fixes #186
