### PR TITLE
docs: add FAQ entry for codex-auto-review model not found error

### DIFF
--- a/docs_source/en/best-practices/codex.md
+++ b/docs_source/en/best-practices/codex.md
@@ -236,6 +236,23 @@ This switches multi-agent tools to the `agents` namespace, avoiding the namespac
 - Confirm your account has permission to access the model
 :::
 
+::: details codex-auto-review Model Not Found
+**Issue**: When using ZenMux as the model provider, Codex reports that the `codex-auto-review` model cannot be found or is not supported, for example:
+
+```
+The supported API model names are ..., but you passed codex-auto-review.
+```
+
+**Cause**: Codex's automatic approval review (auto-review) uses a model named `codex-auto-review` by default to evaluate requests. This model only exists on OpenAI's official backend; ZenMux and any other third-party or self-hosted provider do not have it, so the call sends a non-existent model ID upstream and is rejected. See [openai/codex#31255](https://github.com/openai/codex/issues/31255).
+
+**Solution**: Route approval requests to manual user confirmation instead of the auto-review model:
+
+```toml
+# ~/.codex/config.toml
+approvals_reviewer = "user"  # [!code highlight]
+```
+:::
+
 ## Advanced Configuration
 
 ### Configure Different Models

--- a/docs_source/zh/best-practices/codex.md
+++ b/docs_source/zh/best-practices/codex.md
@@ -235,6 +235,23 @@ tool_namespace = "agents"
 - 确认您的账户是否有权限访问该模型
 :::
 
+::: details 报错 codex-auto-review 模型不存在
+**问题**：使用 ZenMux 作为模型提供商时，Codex 报错提示找不到或不支持 `codex-auto-review` 模型，例如：
+
+```
+The supported API model names are ..., but you passed codex-auto-review.
+```
+
+**原因**：Codex 的自动审批（auto-review）默认使用名为 `codex-auto-review` 的模型来评估请求。该模型仅存在于 OpenAI 官方后端，ZenMux 及其他第三方 / 自建 provider 都没有这个模型，因此调用时会向上游发送一个不存在的模型 ID 而被拒绝。详见 [openai/codex#31255](https://github.com/openai/codex/issues/31255)。
+
+**解决方案**：将审批请求路由给人工确认，不再走自动审批模型：
+
+```toml
+# ~/.codex/config.toml
+approvals_reviewer = "user"  # [!code highlight]
+```
+:::
+
 ## 进阶配置
 
 ### 配置不同模型


### PR DESCRIPTION
## Summary

Adds a new FAQ entry to the Codex CLI troubleshooting guide (both Chinese and English) covering the `codex-auto-review` model-not-found error when using ZenMux as the model provider.

## Changes

- `docs_source/zh/best-practices/codex.md`
- `docs_source/en/best-practices/codex.md`

Both files add a `::: details` block under the troubleshooting section:

- **Symptom**: Codex reports the `codex-auto-review` model cannot be found / is not supported, e.g. `The supported API model names are ..., but you passed codex-auto-review.`
- **Cause**: Codex's auto-review defaults to a model named `codex-auto-review` that only exists on OpenAI's official backend; ZenMux and other third-party / self-hosted providers do not have it, so the call is rejected upstream.
- **Solution**: set `approvals_reviewer = "user"` in `~/.codex/config.toml` to route approval requests to manual confirmation instead of the auto-review model.

## Reference

- Upstream issue: https://github.com/openai/codex/issues/31255