### PR TITLE
docs: add DeepSeek Harness integration guide

### DIFF
--- a/docs_source/en/best-practices/deepseek-harness.md
+++ b/docs_source/en/best-practices/deepseek-harness.md
@@ -1,0 +1,179 @@
+---
+head:
+  - - meta
+    - name: description
+      content: Connect DeepSeek Harness to ZenMux with a standard API key or @zenmux/dsh-plugins OAuth PKCE
+  - - meta
+    - name: keywords
+      content: ZenMux, DeepSeek Harness, DSH, API key, OAuth, PKCE, DeepSeek V4, agent
+---
+
+# DeepSeek Harness Integration
+
+DeepSeek Harness (DSH) supports two ways to connect to ZenMux:
+
+| Method | Plugin required | Best for |
+| --- | --- | --- |
+| Standard API key configuration | No | Users who already have a ZenMux API key and want to use DSH's built-in DeepSeek provider |
+| OAuth PKCE | `@zenmux/dsh-plugins` | Users who prefer browser sign-in without copying or persistently storing an API key |
+
+## Configure a standard API key
+
+The standard configuration reuses DSH's built-in `deepseek-official` provider and does not require the ZenMux PKCE plugin.
+
+First, set your ZenMux API key:
+
+```bash
+export ZENMUX_API_KEY="sk-ai-v1-xxx"
+```
+
+Then edit `$DSH_HOME/settings.yaml`. If `DSH_HOME` is not set, the default path is `~/.dsh/settings.yaml`:
+
+```yaml
+llm-deepseek:
+  apiKeyEnv: ZENMUX_API_KEY
+  baseURL: https://zenmux.ai/api/v1
+```
+
+Start DSH and select the built-in **DeepSeek-V4-Flash** entry or another DeepSeek model supported by ZenMux:
+
+```bash
+dsh web
+```
+
+`apiKeyEnv` stores only the environment-variable name; the API key itself is not written to `settings.yaml`. DSH already provides a default model catalog, so the standard configuration does not need to repeat model entries. Add `models` only when using another model or a custom display name.
+
+For a persistent setup, add `export ZENMUX_API_KEY="..."` to `~/.zshrc` or `~/.bashrc`, depending on the active shell, and then open a new terminal.
+
+If the terminal must reach ZenMux through a proxy, Node.js 24 can be started as follows:
+
+```bash
+HTTPS_PROXY="http://127.0.0.1:7890" NODE_OPTIONS="--use-env-proxy" dsh web
+```
+
+::: tip Verified configuration
+This minimal configuration was tested with DSH `0.1.0-rc.6` and its built-in `deepseek-v4-flash` model. The test used a separate temporary `$DSH_HOME`, did not modify the user's existing configuration, and did not install the PKCE plugin.
+:::
+
+## Use OAuth PKCE
+
+The official `@zenmux/dsh-plugins` npm package uses OAuth 2.0 Authorization Code + PKCE for browser authorization, so no ZenMux API key needs to be created or copied. It also refreshes the sign-in session before the access token expires.
+
+The current PKCE integration targets interactive DSH Web and provides:
+
+- `/zenmux login`, `/zenmux status`, and `/zenmux logout` commands.
+- Browser-based ZenMux OAuth PKCE authorization.
+- Automatic access-token and refresh-token persistence and rotation.
+- Bundled ZenMux DeepSeek V4 Pro and DeepSeek V4 Flash models.
+- Anthropic Messages routing for prompt caching and thinking budgets.
+
+### Install the plugin
+
+Install the package into the DSH Web profile:
+
+```bash
+dsh plugin --profile web add @zenmux/dsh-plugins
+```
+
+Then start DSH Web:
+
+```bash
+dsh web
+```
+
+The package automatically mounts the ZenMux OAuth controller and adds a ZenMux provider to DSH's existing `pi-ai` adapter. It does not replace the built-in DeepSeek route or silently switch existing conversations to a different provider.
+
+### Sign in to ZenMux
+
+Run this command in DSH Web:
+
+```text
+/zenmux login
+```
+
+DSH Web opens the ZenMux authorization page in a new tab and also displays an **Open ZenMux login** fallback link. Confirm the account and requested access, wait for the callback page to display **ZenMux connected**, and then return to DSH.
+
+The plugin requests only these scopes:
+
+- `inference:invoke`: invoke ZenMux models.
+- `offline_access`: refresh the session after the access token expires.
+
+OAuth uses a one-time `127.0.0.1:<ephemeral-port>/callback`. The listener validates `state` and closes after one accepted response or a login timeout.
+
+### Select a model
+
+After sign-in, select one of these entries from the model selector:
+
+- **ZenMux · DeepSeek V4 Pro**
+- **ZenMux · DeepSeek V4 Flash**
+
+These bundled models use the ZenMux Anthropic Messages endpoint so DSH/pi-ai can apply Anthropic prompt caching and thinking budgets.
+
+::: info Models are not discovered automatically
+Current DSH model discovery supports OpenAI-compatible `/models` routes but cannot discover models for an `anthropic-messages` provider. The plugin therefore includes two ready-to-use model entries instead of showing a model refresh action that cannot work.
+:::
+
+To use other ZenMux models, edit the ZenMux provider's `models` array under **Settings → Models**. Enter ZenMux model IDs and configure reasoning levels according to each model's capabilities. Never paste an OAuth token into the model configuration.
+
+### Manage the sign-in state
+
+Check the current connection and expiration time:
+
+```text
+/zenmux status
+```
+
+Sign out:
+
+```text
+/zenmux logout
+```
+
+On logout, the plugin attempts to revoke the refresh token at ZenMux and then clears the stored DSH OAuth credentials. You can also revoke the grant from ZenMux Authorized Apps.
+
+### Proxy and network configuration
+
+OAuth discovery, token, and revocation requests connect directly to ZenMux by default. If the DSH environment requires a proxy, configure `proxyUrl` in the DSH profile or set `HTTPS_PROXY` before startup:
+
+```bash
+export HTTPS_PROXY="http://127.0.0.1:7890"
+dsh web
+```
+
+The plugin supports HTTP, HTTPS, `socks4a://`, and `socks5h://` proxies. An explicit `proxyUrl` in the DSH profile takes priority over environment variables.
+
+::: warning Browser and DSH networking are separate
+The browser must reach the ZenMux authorization page and send the callback to the temporary loopback port on the DSH host. When DSH runs on a remote server or in a container, or when the browser is on another machine, the browser's `127.0.0.1` may not refer to the DSH host.
+:::
+
+If a corporate proxy reissues TLS certificates through a local CA, load that CA before Node.js starts:
+
+```bash
+NODE_EXTRA_CA_CERTS=/absolute/path/to/ca.pem dsh web
+```
+
+Do not use `NODE_TLS_REJECT_UNAUTHORIZED=0`. Disabling TLS verification can expose authorization codes and refresh tokens.
+
+### Optional environment variables
+
+Production normally requires no additional configuration. These variables are primarily for proxies, development, or self-hosted environments:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ZENMUX_OAUTH_ORIGIN` | `https://zenmux.ai` | OAuth authorization-server origin |
+| `ZENMUX_OAUTH_CLIENT_ID` | Bundled public client | Override the OAuth public client ID |
+| `ZENMUX_OAUTH_SCOPES` | `inference:invoke offline_access` | Scopes requested during sign-in |
+| `ZENMUX_API_BASE_URL` | `https://zenmux.ai/api/v1` | ZenMux API base URL |
+| `ZENMUX_ANTHROPIC_BASE_URL` | Derived from the API base URL | Override the Anthropic Messages endpoint |
+| `ZENMUX_OAUTH_NO_BROWSER` | Unset | Set to `1` to suppress automatic browser opening |
+| `HTTPS_PROXY` / `https_proxy` | Unset | Network proxy for OAuth requests |
+
+### Support scope and limitations
+
+- The current package targets interactive DSH Web deployments that can execute `/zenmux` commands.
+- Pure headless and automated deployments that do not consume `ctx.commands` cannot initiate browser sign-in.
+- A headless deployment can reuse credentials created by interactive DSH Web under the same Harness home.
+- The plugin does not add OAuth state, tokens, or expiration data to model input or conversation history.
+- If a configured proxy is unavailable, sign-in and refresh fail instead of silently using another network path.
+
+For the full list of agents that support OAuth PKCE, see [Sign in to ZenMux with OAuth PKCE](/best-practices/oauth-pkce).

--- a/docs_source/en/best-practices/deepseek-harness.md
+++ b/docs_source/en/best-practices/deepseek-harness.md
@@ -17,6 +17,22 @@ DeepSeek Harness (DSH) supports two ways to connect to ZenMux:
 | Standard API key configuration | No | Users who already have a ZenMux API key and want to use DSH's built-in DeepSeek provider |
 | OAuth PKCE | `@zenmux/dsh-plugins` | Users who prefer browser sign-in without copying or persistently storing an API key |
 
+## Install DeepSeek Harness
+
+Install the official `@deepseek-ai/dsh` package globally with npm:
+
+```bash
+npm i -g @deepseek-ai/dsh
+```
+
+Verify that the command is available:
+
+```bash
+dsh --version
+```
+
+If the terminal cannot find `dsh`, open a new terminal and confirm that npm's global executable directory is included in `PATH`.
+
 ## Configure a standard API key
 
 The standard configuration reuses DSH's built-in `deepseek-official` provider and does not require the ZenMux PKCE plugin.

--- a/docs_source/en/best-practices/oauth-pkce.md
+++ b/docs_source/en/best-practices/oauth-pkce.md
@@ -18,7 +18,7 @@ The following agents are currently supported:
 | --- | --- | --- |
 | OpenClaw | `@zenmux/openclaw-plugin` | `openclaw models auth login --provider zenmux` |
 | Codex CLI / Codex App | `@zenmux/codex-oauth` | `zenmux-codex-auth login` |
-| DeepSeek Harness (DSH Web) | `@zenmux/dsh-plugins` | `/zenmux login` |
+| [DeepSeek Harness (DSH Web)](/best-practices/deepseek-harness) | `@zenmux/dsh-plugins` | `/zenmux login` |
 | OpenCode | `@zenmux/opencode-oauth` | `/connect` or `opencode auth login` |
 | Pi | `@zenmux/pi-zenmux-oauth` | `/login zenmux` |
 
@@ -94,6 +94,8 @@ npm uninstall -g @zenmux/codex-oauth
 ```
 
 ## DeepSeek Harness
+
+For complete installation, proxy, and model configuration details, see [DeepSeek Harness Integration](/best-practices/deepseek-harness).
 
 Install the ZenMux bundle into the DSH Web profile, then start DSH:
 

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -343,6 +343,14 @@ export default defineLoacaleConfig({
           text: "Integrations",
           items: [
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/zBEE8Dm/Property-1CC-Switch.svg" />CC-Switch Integration',
+              link: "/best-practices/cc-switch",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aA2YGDk/Property-1cherrystudio.svg" />Cherry Studio Integration',
+              link: "/best-practices/cherry-studio",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/HTMS2Uv/Property-1Calude.svg" />Claude Code Integration',
               link: "/best-practices/claude-code",
             },
@@ -351,76 +359,68 @@ export default defineLoacaleConfig({
               link: "/best-practices/claude-desktop",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/3e4UfxM/Property-1Codex.svg" />CodeX CLI + Codex APP Integration',
-              link: "/best-practices/codex",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness Integration',
-              link: "/best-practices/deepseek-harness",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI Integration',
-              link: "/best-practices/gemini-cli",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aJSfGT3/Property-1opencode.svg" />OpenCode Integration',
-              link: "/best-practices/opencode",
-            },
-            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/ev9eqnc/Property-1cline.svg" />Cline Integration',
               link: "/best-practices/cline",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aA2YGDk/Property-1cherrystudio.svg" />Cherry Studio Integration',
-              link: "/best-practices/cherry-studio",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/e8rAwRd/Property-1obsidian.svg" />Obsidian Integration',
-              link: "/best-practices/obsidian",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/J4cCdCL/Property-1Sider.svg" />Sider Integration',
-              link: "/best-practices/sider",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/BaUQozX/Property-1openwebui.svg" />Open-WebUI Integration',
-              link: "/best-practices/open-webui",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/YziH1Wm/Property-1dify.svg" />Dify Integration',
-              link: "/best-practices/dify",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/hVDPe9M/Property-1Neovate.svg" />Neovate Integration',
-              link: "/best-practices/neovate-code",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/Tbnm5fx/Property-1githubcopilot.svg" />Github Copilot Integration',
-              link: "/best-practices/github-copilot",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />OpenClaw Integration',
-              link: "/best-practices/openclaw",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />Deploying OpenClaw on Alibaba Cloud with ZenMux Integration',
-              link: "/best-practices/openclaw-alibaba",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/zBEE8Dm/Property-1CC-Switch.svg" />CC-Switch Integration',
-              link: "/best-practices/cc-switch",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/3e4UfxM/Property-1Codex.svg" />CodeX CLI + Codex APP Integration',
+              link: "/best-practices/codex",
             },
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/cT6lvK5/Property-1Cursor.svg" />Cursor Integration',
               link: "/best-practices/cursor",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub Integration',
-              link: "/best-practices/rikkahub",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness Integration',
+              link: "/best-practices/deepseek-harness",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />Deploying OpenClaw on Alibaba Cloud with ZenMux Integration',
+              link: "/best-practices/openclaw-alibaba",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/YziH1Wm/Property-1dify.svg" />Dify Integration',
+              link: "/best-practices/dify",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI Integration',
+              link: "/best-practices/gemini-cli",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/Tbnm5fx/Property-1githubcopilot.svg" />Github Copilot Integration',
+              link: "/best-practices/github-copilot",
             },
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/jT0X0zI/Property-1Hermes.svg" />Hermes Agent Integration',
               link: "/best-practices/hermes-agent",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/hVDPe9M/Property-1Neovate.svg" />Neovate Integration',
+              link: "/best-practices/neovate-code",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/e8rAwRd/Property-1obsidian.svg" />Obsidian Integration',
+              link: "/best-practices/obsidian",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />OpenClaw Integration',
+              link: "/best-practices/openclaw",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aJSfGT3/Property-1opencode.svg" />OpenCode Integration',
+              link: "/best-practices/opencode",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/BaUQozX/Property-1openwebui.svg" />Open-WebUI Integration',
+              link: "/best-practices/open-webui",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub Integration',
+              link: "/best-practices/rikkahub",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/J4cCdCL/Property-1Sider.svg" />Sider Integration',
+              link: "/best-practices/sider",
             },
           ],
         },

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -343,10 +343,6 @@ export default defineLoacaleConfig({
           text: "Integrations",
           items: [
             {
-              text: "OAuth PKCE Integration Guide",
-              link: "/best-practices/oauth-pkce",
-            },
-            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/HTMS2Uv/Property-1Calude.svg" />Claude Code Integration',
               link: "/best-practices/claude-code",
             },
@@ -434,6 +430,15 @@ export default defineLoacaleConfig({
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/07/28/nX2cLeT/network-environments.svg" />Agent Tools Proxy Configuration Guide',
               link: "/best-practices/network-environments",
+            },
+          ],
+        },
+        {
+          text: "OAuth",
+          items: [
+            {
+              text: "OAuth PKCE Integration Guide",
+              link: "/best-practices/oauth-pkce",
             },
           ],
         },

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -437,7 +437,7 @@ export default defineLoacaleConfig({
           text: "OAuth",
           items: [
             {
-              text: "OAuth PKCE Integration Guide",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/08/14/nQf3Lhi/OAuth-20-Logo.png" />OAuth PKCE Integration Guide',
               link: "/best-practices/oauth-pkce",
             },
           ],

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -359,6 +359,10 @@ export default defineLoacaleConfig({
               link: "/best-practices/codex",
             },
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness Integration',
+              link: "/best-practices/deepseek-harness",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI Integration',
               link: "/best-practices/gemini-cli",
             },

--- a/docs_source/zh/best-practices/deepseek-harness.md
+++ b/docs_source/zh/best-practices/deepseek-harness.md
@@ -17,6 +17,22 @@ DeepSeek Harness（DSH）支持两种方式接入 ZenMux：
 | 普通 API Key 配置 | 不需要 | 已有 ZenMux API Key，希望直接使用 DSH 内置 DeepSeek Provider |
 | OAuth PKCE | 需要 `@zenmux/dsh-plugins` | 希望通过浏览器登录，不复制或长期保存 API Key |
 
+## 安装 DeepSeek Harness
+
+使用 npm 全局安装官方 `@deepseek-ai/dsh` 包：
+
+```bash
+npm i -g @deepseek-ai/dsh
+```
+
+安装完成后检查命令是否可用：
+
+```bash
+dsh --version
+```
+
+如果终端提示找不到 `dsh`，请重新打开终端，并确认 npm 全局可执行文件目录已加入 `PATH`。
+
 ## 使用普通 API Key 配置
 
 普通配置直接复用 DSH 内置的 `deepseek-official` Provider，不需要安装 ZenMux PKCE 插件。

--- a/docs_source/zh/best-practices/deepseek-harness.md
+++ b/docs_source/zh/best-practices/deepseek-harness.md
@@ -1,0 +1,179 @@
+---
+head:
+  - - meta
+    - name: description
+      content: 使用普通 API Key 或 @zenmux/dsh-plugins OAuth PKCE 将 DeepSeek Harness 接入 ZenMux
+  - - meta
+    - name: keywords
+      content: ZenMux, DeepSeek Harness, DSH, API Key, OAuth, PKCE, DeepSeek V4, Agent
+---
+
+# DeepSeek Harness 接入 ZenMux
+
+DeepSeek Harness（DSH）支持两种方式接入 ZenMux：
+
+| 方式 | 是否需要插件 | 适用场景 |
+| --- | --- | --- |
+| 普通 API Key 配置 | 不需要 | 已有 ZenMux API Key，希望直接使用 DSH 内置 DeepSeek Provider |
+| OAuth PKCE | 需要 `@zenmux/dsh-plugins` | 希望通过浏览器登录，不复制或长期保存 API Key |
+
+## 使用普通 API Key 配置
+
+普通配置直接复用 DSH 内置的 `deepseek-official` Provider，不需要安装 ZenMux PKCE 插件。
+
+先设置 ZenMux API Key：
+
+```bash
+export ZENMUX_API_KEY="sk-ai-v1-xxx"
+```
+
+然后编辑 `$DSH_HOME/settings.yaml`；如果未设置 `DSH_HOME`，默认路径为 `~/.dsh/settings.yaml`：
+
+```yaml
+llm-deepseek:
+  apiKeyEnv: ZENMUX_API_KEY
+  baseURL: https://zenmux.ai/api/v1
+```
+
+启动 DSH，并在模型选择器中选择内置的 **DeepSeek-V4-Flash** 或其他 ZenMux 支持的 DeepSeek 模型：
+
+```bash
+dsh web
+```
+
+`apiKeyEnv` 只保存环境变量名称，API Key 本身不会写入 `settings.yaml`。DSH 已内置默认模型列表，因此普通配置不需要重复填写模型；只有使用其他模型或自定义显示名称时才需要增加 `models`。
+
+如果需要让 API Key 长期生效，请根据当前 Shell 将 `export ZENMUX_API_KEY="..."` 写入 `~/.zshrc` 或 `~/.bashrc`，然后重新打开终端。
+
+如果终端必须通过代理访问 ZenMux，Node.js 24 可以这样启动：
+
+```bash
+HTTPS_PROXY="http://127.0.0.1:7890" NODE_OPTIONS="--use-env-proxy" dsh web
+```
+
+::: tip 已验证配置
+以上最小配置已使用 DSH `0.1.0-rc.6` 和其内置的 `deepseek-v4-flash` 发起真实请求并获得正常响应。测试使用独立的临时 `$DSH_HOME`，没有修改用户已有配置，也没有安装 PKCE 插件。
+:::
+
+## 使用 OAuth PKCE
+
+官方 npm 包 `@zenmux/dsh-plugins` 使用 OAuth 2.0 Authorization Code + PKCE 完成浏览器授权，无需创建或复制 ZenMux API Key，并会在 Access Token 到期前自动刷新登录状态。
+
+当前 PKCE 集成面向交互式 DSH Web，提供以下能力：
+
+- `/zenmux login`、`/zenmux status` 和 `/zenmux logout` 命令。
+- 通过浏览器完成 ZenMux OAuth PKCE 授权。
+- 自动保存并轮换 Access Token 与 Refresh Token。
+- 预置 ZenMux DeepSeek V4 Pro 和 DeepSeek V4 Flash 模型。
+- 通过 Anthropic Messages 协议使用提示词缓存与思考预算。
+
+### 安装插件
+
+将插件安装到 DSH Web Profile：
+
+```bash
+dsh plugin --profile web add @zenmux/dsh-plugins
+```
+
+然后启动 DSH Web：
+
+```bash
+dsh web
+```
+
+安装包会自动挂载 ZenMux OAuth 控制器，并在 DSH 已有的 `pi-ai` Adapter 中加入 ZenMux Provider。它不会替换 DSH 内置的 DeepSeek 路由，也不会自动切换已有对话的 Provider。
+
+### 登录 ZenMux
+
+在 DSH Web 中执行：
+
+```text
+/zenmux login
+```
+
+DSH Web 会在新标签页打开 ZenMux 授权页，同时显示一个 **打开 ZenMux 登录** 的备用链接。确认账号和授权范围后，等待回调页面显示 **ZenMux connected**，然后返回 DSH。
+
+插件只请求以下权限：
+
+- `inference:invoke`：调用 ZenMux 模型。
+- `offline_access`：在 Access Token 过期后刷新登录状态。
+
+OAuth 回调使用一次性的 `127.0.0.1:<临时端口>/callback`。监听器会校验 `state`，并在成功接收一次响应或登录超时后关闭。
+
+### 选择模型
+
+登录成功后，在模型选择器中选择：
+
+- **ZenMux · DeepSeek V4 Pro**
+- **ZenMux · DeepSeek V4 Flash**
+
+这两个预置模型通过 ZenMux 的 Anthropic Messages 端点调用，以便 DSH/pi-ai 使用 Anthropic 提示词缓存和思考预算。
+
+::: info 模型不会自动刷新
+当前 DSH 自动模型发现只支持 OpenAI 兼容的 `/models` 路由，还不能为 `anthropic-messages` Provider 自动发现模型。因此插件提供两个可直接使用的初始模型，不显示无效的模型刷新入口。
+:::
+
+如需使用其他 ZenMux 模型，可以在 **设置 → 模型** 中编辑 ZenMux Provider 的 `models` 数组。请填写 ZenMux 模型 ID，并根据模型能力配置推理等级。不要把 OAuth Token 粘贴到模型配置中。
+
+### 管理登录状态
+
+查看当前连接状态和到期时间：
+
+```text
+/zenmux status
+```
+
+退出登录：
+
+```text
+/zenmux logout
+```
+
+退出时，插件会尝试在 ZenMux 撤销 Refresh Token，然后清除 DSH 中保存的 OAuth 凭据。还可以前往 ZenMux 的已授权应用页面撤销该授权。
+
+### 代理与网络配置
+
+OAuth Discovery、Token 和 Revocation 请求默认直接连接 ZenMux。如果 DSH 所在环境必须使用代理，可以在 DSH Profile 中配置 `proxyUrl`，或在启动前设置 `HTTPS_PROXY`：
+
+```bash
+export HTTPS_PROXY="http://127.0.0.1:7890"
+dsh web
+```
+
+插件支持 HTTP、HTTPS、`socks4a://` 和 `socks5h://` 代理。DSH Profile 中显式配置的 `proxyUrl` 优先于环境变量。
+
+::: warning 浏览器与 DSH 网络相互独立
+浏览器需要能够访问 ZenMux 授权页，并将回调发送到运行 DSH 的临时 Loopback 端口。远程服务器、容器或浏览器不在同一台机器时，浏览器中的 `127.0.0.1` 不一定指向 DSH 主机。
+:::
+
+如果企业代理使用本地 CA 重新签发 TLS 证书，应在 Node.js 启动前加载 CA：
+
+```bash
+NODE_EXTRA_CA_CERTS=/absolute/path/to/ca.pem dsh web
+```
+
+不要使用 `NODE_TLS_REJECT_UNAUTHORIZED=0`。关闭 TLS 校验可能暴露 Authorization Code 和 Refresh Token。
+
+### 可选环境变量
+
+生产环境通常不需要额外配置。以下变量主要用于代理环境、开发环境或自托管服务：
+
+| 变量 | 默认值 | 用途 |
+| --- | --- | --- |
+| `ZENMUX_OAUTH_ORIGIN` | `https://zenmux.ai` | OAuth 授权服务器地址 |
+| `ZENMUX_OAUTH_CLIENT_ID` | 随包 Public Client | 覆盖 OAuth Public Client ID |
+| `ZENMUX_OAUTH_SCOPES` | `inference:invoke offline_access` | 登录请求的权限范围 |
+| `ZENMUX_API_BASE_URL` | `https://zenmux.ai/api/v1` | ZenMux API 基础地址 |
+| `ZENMUX_ANTHROPIC_BASE_URL` | 从 API Base URL 派生 | 覆盖 Anthropic Messages 端点 |
+| `ZENMUX_OAUTH_NO_BROWSER` | 未设置 | 设为 `1` 时不自动打开浏览器 |
+| `HTTPS_PROXY` / `https_proxy` | 未设置 | OAuth 请求使用的网络代理 |
+
+### 支持范围与限制
+
+- 当前包面向能够执行 `/zenmux` 命令的交互式 DSH Web。
+- 不消费 `ctx.commands` 的纯 Headless 或自动化部署不能自行发起浏览器登录。
+- Headless 部署可以复用同一个 Harness Home 中由交互式 DSH Web 创建的凭据。
+- 插件不会把 OAuth 状态、Token 或到期时间加入模型输入或对话历史。
+- 代理不可用时登录与刷新会失败，不会静默回退到其他网络路径。
+
+需要了解所有支持 OAuth PKCE 的 Agent，请参阅[使用 OAuth PKCE 登录 ZenMux](/zh/best-practices/oauth-pkce)。

--- a/docs_source/zh/best-practices/oauth-pkce.md
+++ b/docs_source/zh/best-practices/oauth-pkce.md
@@ -18,7 +18,7 @@ ZenMux 支持通过 OAuth 2.0 Authorization Code + PKCE 将账号授权给本地
 | --- | --- | --- |
 | OpenClaw | `@zenmux/openclaw-plugin` | `openclaw models auth login --provider zenmux` |
 | Codex CLI / Codex App | `@zenmux/codex-oauth` | `zenmux-codex-auth login` |
-| DeepSeek Harness（DSH Web） | `@zenmux/dsh-plugins` | `/zenmux login` |
+| [DeepSeek Harness（DSH Web）](/zh/best-practices/deepseek-harness) | `@zenmux/dsh-plugins` | `/zenmux login` |
 | OpenCode | `@zenmux/opencode-oauth` | `/connect` 或 `opencode auth login` |
 | Pi | `@zenmux/pi-zenmux-oauth` | `/login zenmux` |
 
@@ -94,6 +94,8 @@ npm uninstall -g @zenmux/codex-oauth
 ```
 
 ## DeepSeek Harness
+
+完整安装、代理和模型配置说明请参阅 [DeepSeek Harness 接入 ZenMux](/zh/best-practices/deepseek-harness)。
 
 将 ZenMux 插件安装到 DSH Web Profile，然后启动 DSH：
 

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -445,7 +445,7 @@ export default defineLoacaleConfig({
           text: "OAuth",
           items: [
             {
-              text: "OAuth PKCE 接入指南",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/08/14/nQf3Lhi/OAuth-20-Logo.png" />OAuth PKCE 接入指南',
               link: "/zh/best-practices/oauth-pkce",
             },
           ],

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -351,6 +351,14 @@ export default defineLoacaleConfig({
           text: "最佳实践",
           items: [
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/zBEE8Dm/Property-1CC-Switch.svg" />CC-Switch 接入 ZenMux 指南',
+              link: "/zh/best-practices/cc-switch",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aA2YGDk/Property-1cherrystudio.svg" />CherryStudio接入ZenMux指南',
+              link: "/zh/best-practices/cherry-studio",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/HTMS2Uv/Property-1Calude.svg" />ClaudeCode接入ZenMux指南',
               link: "/zh/best-practices/claude-code",
             },
@@ -359,76 +367,68 @@ export default defineLoacaleConfig({
               link: "/zh/best-practices/claude-desktop",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/3e4UfxM/Property-1Codex.svg" />CodeX CLI + Codex APP 接入ZenMux指南',
-              link: "/zh/best-practices/codex",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness 接入 ZenMux 指南',
-              link: "/zh/best-practices/deepseek-harness",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI接入ZenMux指南',
-              link: "/zh/best-practices/gemini-cli",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aJSfGT3/Property-1opencode.svg" />OpenCode 接入ZenMux指南',
-              link: "/zh/best-practices/opencode",
-            },
-            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/ev9eqnc/Property-1cline.svg" />Cline接入ZenMux指南',
               link: "/zh/best-practices/cline",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aA2YGDk/Property-1cherrystudio.svg" />CherryStudio接入ZenMux指南',
-              link: "/zh/best-practices/cherry-studio",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/e8rAwRd/Property-1obsidian.svg" />Obsidian接入ZenMux指南',
-              link: "/zh/best-practices/obsidian",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/J4cCdCL/Property-1Sider.svg" />Sider接入ZenMux指南',
-              link: "/zh/best-practices/sider",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/BaUQozX/Property-1openwebui.svg" />Open-WebUI接入ZenMux指南',
-              link: "/zh/best-practices/open-webui",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/YziH1Wm/Property-1dify.svg" />Dify接入ZenMux指南',
-              link: "/zh/best-practices/dify",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/hVDPe9M/Property-1Neovate.svg" />Neovate接入ZenMux指南',
-              link: "/zh/best-practices/neovate-code",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/Tbnm5fx/Property-1githubcopilot.svg" />Github Copilot 接入 ZenMux 指南',
-              link: "/zh/best-practices/github-copilot",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />OpenClaw 接入 ZenMux 指南',
-              link: "/zh/best-practices/openclaw",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />阿里云部署 OpenClaw 并集成 ZenMux 指南',
-              link: "/zh/best-practices/openclaw-alibaba",
-            },
-            {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/zBEE8Dm/Property-1CC-Switch.svg" />CC-Switch 接入 ZenMux 指南',
-              link: "/zh/best-practices/cc-switch",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/3e4UfxM/Property-1Codex.svg" />CodeX CLI + Codex APP 接入ZenMux指南',
+              link: "/zh/best-practices/codex",
             },
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/cT6lvK5/Property-1Cursor.svg" />Cursor 接入 ZenMux 指南',
               link: "/zh/best-practices/cursor",
             },
             {
-              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub 接入 ZenMux 指南',
-              link: "/zh/best-practices/rikkahub",
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness 接入 ZenMux 指南',
+              link: "/zh/best-practices/deepseek-harness",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />阿里云部署 OpenClaw 并集成 ZenMux 指南',
+              link: "/zh/best-practices/openclaw-alibaba",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/YziH1Wm/Property-1dify.svg" />Dify接入ZenMux指南',
+              link: "/zh/best-practices/dify",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI接入ZenMux指南',
+              link: "/zh/best-practices/gemini-cli",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/Tbnm5fx/Property-1githubcopilot.svg" />Github Copilot 接入 ZenMux 指南',
+              link: "/zh/best-practices/github-copilot",
             },
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/jT0X0zI/Property-1Hermes.svg" />Hermes Agent 接入 ZenMux 指南',
               link: "/zh/best-practices/hermes-agent",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/hVDPe9M/Property-1Neovate.svg" />Neovate接入ZenMux指南',
+              link: "/zh/best-practices/neovate-code",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/e8rAwRd/Property-1obsidian.svg" />Obsidian接入ZenMux指南',
+              link: "/zh/best-practices/obsidian",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/i0H2J7w/Property-1openclaw.svg" />OpenClaw 接入 ZenMux 指南',
+              link: "/zh/best-practices/openclaw",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/aJSfGT3/Property-1opencode.svg" />OpenCode 接入ZenMux指南',
+              link: "/zh/best-practices/opencode",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/BaUQozX/Property-1openwebui.svg" />Open-WebUI接入ZenMux指南',
+              link: "/zh/best-practices/open-webui",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub 接入 ZenMux 指南',
+              link: "/zh/best-practices/rikkahub",
+            },
+            {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/J4cCdCL/Property-1Sider.svg" />Sider接入ZenMux指南',
+              link: "/zh/best-practices/sider",
             },
           ],
         },

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -351,10 +351,6 @@ export default defineLoacaleConfig({
           text: "最佳实践",
           items: [
             {
-              text: "OAuth PKCE 接入指南",
-              link: "/zh/best-practices/oauth-pkce",
-            },
-            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/HTMS2Uv/Property-1Calude.svg" />ClaudeCode接入ZenMux指南',
               link: "/zh/best-practices/claude-code",
             },
@@ -442,6 +438,15 @@ export default defineLoacaleConfig({
             {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/07/28/nX2cLeT/network-environments.svg" />Agent 工具代理配置指南',
               link: "/zh/best-practices/network-environments",
+            },
+          ],
+        },
+        {
+          text: "OAuth",
+          items: [
+            {
+              text: "OAuth PKCE 接入指南",
+              link: "/zh/best-practices/oauth-pkce",
             },
           ],
         },

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -367,6 +367,10 @@ export default defineLoacaleConfig({
               link: "/zh/best-practices/codex",
             },
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2025/10/15/tmeJLqx/Property-1deepseek.svg" />DeepSeek Harness 接入 ZenMux 指南',
+              link: "/zh/best-practices/deepseek-harness",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/LksmNgb/Property-1Gemini.svg" />Gemini CLI接入ZenMux指南',
               link: "/zh/best-practices/gemini-cli",
             },


### PR DESCRIPTION
## What changed

- add bilingual DeepSeek Harness integration documentation
- document both standard `ZENMUX_API_KEY` configuration and optional OAuth PKCE login
- add the DeepSeek Harness entry and supplied logo to both integration menus
- link the OAuth PKCE overview to the dedicated guide

## Why

DeepSeek Harness supports a direct configuration through its built-in DeepSeek provider as well as browser-based OAuth through `@zenmux/dsh-plugins`. The documentation needs to present both paths clearly instead of implying the PKCE plugin is required.

## Validation

- tested DSH `0.1.0-rc.6` with an isolated `$DSH_HOME`
- completed a real `deepseek-v4-flash` request using `ZENMUX_API_KEY`, without the PKCE plugin
- verified PKCE plugin installation and authorization URL generation
- `git diff --check`
- `pnpm exec vitepress build docs_source --outDir /tmp/zenmux-deepseek-harness-doc-build`
