### PR TITLE
docs: add OAuth client registration notice

### DIFF
--- a/docs_source/en/best-practices/oauth-pkce.md
+++ b/docs_source/en/best-practices/oauth-pkce.md
@@ -22,6 +22,10 @@ The following agents are currently supported:
 | OpenCode | `@zenmux/opencode-oauth` | `/connect` or `opencode auth login` |
 | Pi | `@zenmux/pi-zenmux-oauth` | `/login zenmux` |
 
+::: info Register a new OAuth client
+OAuth clients are currently registered by the ZenMux backend. To register a client for a new agent or application, email [support@zenmux.ai](mailto:support@zenmux.ai) with the application name, project or package URL, redirect URI, requested scopes, and contact information.
+:::
+
 ::: tip OAuth PKCE versus API keys
 OAuth PKCE authorization is tied to your ZenMux user and an authorization grant. It does not distribute a client secret to the plugin and does not require writing an API key into your shell configuration. You can revoke access at any time from ZenMux Authorized Apps.
 :::

--- a/docs_source/zh/best-practices/oauth-pkce.md
+++ b/docs_source/zh/best-practices/oauth-pkce.md
@@ -22,6 +22,10 @@ ZenMux 支持通过 OAuth 2.0 Authorization Code + PKCE 将账号授权给本地
 | OpenCode | `@zenmux/opencode-oauth` | `/connect` 或 `opencode auth login` |
 | Pi | `@zenmux/pi-zenmux-oauth` | `/login zenmux` |
 
+::: info 注册新的 OAuth Client
+目前 OAuth Client 只能由 ZenMux 后端注册。如果你需要为新的 Agent 或应用注册 Client，请发送邮件至 [support@zenmux.ai](mailto:support@zenmux.ai)，并提供应用名称、项目或包地址、Redirect URI、所需 Scope 和联系人信息。
+:::
+
 ::: tip OAuth PKCE 与 API Key 的区别
 OAuth PKCE 授权绑定到当前 ZenMux 用户和授权记录，不会向插件分发客户端密钥，也不需要把 API Key 写入 shell 配置。你可以随时在 ZenMux 的已授权应用中撤销访问。
 :::


### PR DESCRIPTION
## What changed

- Add a visible OAuth client registration notice to the English and Chinese OAuth PKCE guides.
- Direct developers to `support@zenmux.ai` when a new agent or application needs an OAuth client.
- List the information needed for registration, including redirect URI and requested scopes.

## Why

OAuth clients currently require backend registration. The documentation should make this limitation and the registration path clear before developers begin integration.

## Validation

- `git diff --check`
- `pnpm exec vitepress build docs_source --outDir /tmp/zenmux-oauth-client-registration-build`
