### PR TITLE
docs: add Pi Coding Agent integration guide

### DIFF
--- a/docs_source/en/best-practices/pi-coding-agent.md
+++ b/docs_source/en/best-practices/pi-coding-agent.md
@@ -1,0 +1,163 @@
+---
+head:
+  - - meta
+    - name: description
+      content: Connect Pi Coding Agent to ZenMux with a standard API key or the @zenmux/pi-zenmux-oauth OAuth PKCE extension
+  - - meta
+    - name: keywords
+      content: ZenMux, Pi Coding Agent, API key, OAuth, PKCE, coding agent, models.json
+---
+
+# Pi Coding Agent Integration
+
+Pi Coding Agent supports two ways to connect to ZenMux:
+
+| Method | Extension required | Best for |
+| --- | --- | --- |
+| Standard API key configuration | No | Users who already have a ZenMux API key and want to configure specific models manually |
+| OAuth PKCE | `@zenmux/pi-zenmux-oauth` | Users who prefer browser sign-in, automatic token refresh, and dynamic model discovery |
+
+## Install Pi Coding Agent
+
+Pi now uses the official `@earendil-works/pi-coding-agent` package and requires Node.js 22.19.0 or later:
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+Verify the installation:
+
+```bash
+pi --version
+```
+
+::: warning Migrating from the old package
+The former `@mariozechner/pi-coding-agent` package is deprecated. If it is still installed, uninstall it before installing the current package:
+
+```bash
+npm uninstall -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
+```
+:::
+
+## Configure a standard API key
+
+This method uses Pi's native custom-provider support and does not install the ZenMux OAuth extension.
+
+First, set your ZenMux API key:
+
+```bash
+export ZENMUX_API_KEY="sk-ai-v1-xxx"
+```
+
+Then add a `zenmux` provider to `~/.pi/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "zenmux": {
+      "baseUrl": "https://zenmux.ai/api/v1",
+      "api": "openai-completions",
+      "apiKey": "$ZENMUX_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek V4 Flash"
+        }
+      ]
+    }
+  }
+}
+```
+
+If `models.json` already contains other providers, merge the `zenmux` entry into the existing `providers` object instead of replacing the file. Add more entries to `models` when you want to use other ZenMux model IDs.
+
+Start Pi, run `/model`, and select `zenmux/deepseek-v4-flash`. You can also select it at startup:
+
+```bash
+pi --provider zenmux --model deepseek-v4-flash
+```
+
+`apiKey` contains an environment-variable reference, not the API key itself. For persistent use, add the export command to the startup file for your active shell, such as `~/.zshrc` or `~/.bashrc`, and then open a new terminal.
+
+::: tip Why models must be listed here
+Pi's standard custom-provider configuration does not automatically import the ZenMux model catalog. Each model used through this method must be present in `models.json`. Use the OAuth method below if you want Pi to discover the current catalog automatically.
+:::
+
+## Use OAuth PKCE
+
+The official `@zenmux/pi-zenmux-oauth` extension opens ZenMux in your browser for authorization. It does not require a ZenMux API key and refreshes OAuth tokens automatically.
+
+Install the extension with Pi:
+
+```bash
+pi install npm:@zenmux/pi-zenmux-oauth
+```
+
+Start Pi and sign in:
+
+```text
+/login zenmux
+```
+
+Approve the request in the browser. After the callback page confirms the connection, return to Pi, run `/model`, and select a ZenMux model.
+
+The extension:
+
+- Discovers the current ZenMux model catalog and caches the last valid catalog at `~/.pi/agent/models-store.json`.
+- Selects Anthropic Messages, OpenAI Responses, or Chat Completions for each model according to the protocols advertised by ZenMux.
+- Stores access and refresh tokens in Pi's provider credential store and saves rotated refresh tokens.
+- Requests only `inference:invoke` and `offline_access` scopes.
+
+To sign out, run `/logout` in Pi and select ZenMux. You can also revoke the authorization from ZenMux Authorized Apps.
+
+For details about the authorization flow and credential security, see [OAuth PKCE Integration Guide](/best-practices/oauth-pkce).
+
+## Choose between the two methods
+
+| Capability | Standard API key | OAuth PKCE |
+| --- | --- | --- |
+| Authentication | `ZENMUX_API_KEY` | Browser authorization |
+| Extra extension | Not required | `@zenmux/pi-zenmux-oauth` |
+| Model setup | Add model IDs to `models.json` | Discover models automatically |
+| Protocol selection | Defined by `api` in `models.json` | Selected per model from the ZenMux catalog |
+| Credential lifecycle | Managed by the user | Access-token refresh and rotation handled automatically |
+
+## Troubleshooting
+
+### The ZenMux model does not appear
+
+For standard API key configuration, confirm that:
+
+- `~/.pi/agent/models.json` is valid JSON.
+- The provider contains `baseUrl`, `api`, and at least one model ID.
+- `ZENMUX_API_KEY` is available in the same terminal that starts Pi.
+
+Check the loaded model directly:
+
+```bash
+pi --list-models zenmux
+```
+
+For OAuth, confirm that the extension is installed:
+
+```bash
+pi list
+```
+
+If necessary, update it and sign in again:
+
+```bash
+pi update npm:@zenmux/pi-zenmux-oauth
+```
+
+### The browser opens but authorization does not finish
+
+The OAuth callback uses a temporary port on `127.0.0.1`. The browser and Pi must reach the same machine's loopback address. Remote servers, containers, SSH sessions, and browser proxies may require port forwarding or a local Pi session.
+
+### Requests return 401
+
+- Standard API key: verify that `ZENMUX_API_KEY` is current and was exported before Pi started.
+- OAuth: run `/login zenmux` again. If the problem remains, revoke the old grant from ZenMux Authorized Apps and authorize again.
+
+Never paste an API key or OAuth token into prompts, project files, logs, or screenshots.

--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -415,6 +415,10 @@ export default defineLoacaleConfig({
               link: "/best-practices/open-webui",
             },
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/08/17/AiPNvoR/Pi-Logo-black-outline.svg" />Pi Coding Agent Integration',
+              link: "/best-practices/pi-coding-agent",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub Integration',
               link: "/best-practices/rikkahub",
             },

--- a/docs_source/zh/best-practices/pi-coding-agent.md
+++ b/docs_source/zh/best-practices/pi-coding-agent.md
@@ -1,0 +1,163 @@
+---
+head:
+  - - meta
+    - name: description
+      content: 使用普通 API Key 或 @zenmux/pi-zenmux-oauth OAuth PKCE 扩展将 Pi Coding Agent 接入 ZenMux
+  - - meta
+    - name: keywords
+      content: ZenMux, Pi Coding Agent, API Key, OAuth, PKCE, 编程 Agent, models.json
+---
+
+# Pi Coding Agent 接入 ZenMux
+
+Pi Coding Agent 支持两种 ZenMux 接入方式：
+
+| 方式 | 是否需要扩展 | 适用场景 |
+| --- | --- | --- |
+| 普通 API Key 配置 | 否 | 已有 ZenMux API Key，希望手动配置指定模型 |
+| OAuth PKCE | `@zenmux/pi-zenmux-oauth` | 希望通过浏览器登录、自动刷新令牌并动态获取模型列表 |
+
+## 安装 Pi Coding Agent
+
+Pi 目前使用官方包 `@earendil-works/pi-coding-agent`，需要 Node.js 22.19.0 或更高版本：
+
+```bash
+npm install -g @earendil-works/pi-coding-agent
+```
+
+验证安装结果：
+
+```bash
+pi --version
+```
+
+::: warning 从旧包迁移
+原来的 `@mariozechner/pi-coding-agent` 已弃用。如果系统中仍安装了旧包，请先卸载，再安装当前版本：
+
+```bash
+npm uninstall -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
+```
+:::
+
+## 配置普通 API Key
+
+这种方式直接使用 Pi 自带的自定义 Provider 能力，不需要安装 ZenMux OAuth 扩展。
+
+首先设置 ZenMux API Key：
+
+```bash
+export ZENMUX_API_KEY="sk-ai-v1-xxx"
+```
+
+然后在 `~/.pi/agent/models.json` 中添加 `zenmux` Provider：
+
+```json
+{
+  "providers": {
+    "zenmux": {
+      "baseUrl": "https://zenmux.ai/api/v1",
+      "api": "openai-completions",
+      "apiKey": "$ZENMUX_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-v4-flash",
+          "name": "DeepSeek V4 Flash"
+        }
+      ]
+    }
+  }
+}
+```
+
+如果 `models.json` 已经包含其他 Provider，请把 `zenmux` 合并到现有的 `providers` 对象中，不要覆盖整个文件。需要使用其他 ZenMux 模型时，在 `models` 数组中继续添加对应的模型 ID。
+
+启动 Pi，运行 `/model`，选择 `zenmux/deepseek-v4-flash`。也可以在启动时直接选择：
+
+```bash
+pi --provider zenmux --model deepseek-v4-flash
+```
+
+这里的 `apiKey` 保存的是环境变量引用，不会把 API Key 本身写入 `models.json`。如果需要长期使用，请根据当前 Shell，把 export 命令加入 `~/.zshrc` 或 `~/.bashrc`，然后重新打开终端。
+
+::: tip 为什么这里需要填写模型
+Pi 的普通自定义 Provider 配置不会自动导入 ZenMux 模型目录，因此需要在 `models.json` 中列出要使用的模型。如果希望自动获取当前可用模型，请使用下面的 OAuth 方式。
+:::
+
+## 使用 OAuth PKCE
+
+官方扩展 `@zenmux/pi-zenmux-oauth` 会在浏览器中打开 ZenMux 授权页面，不需要创建或复制 ZenMux API Key，并会自动刷新 OAuth Token。
+
+使用 Pi 安装扩展：
+
+```bash
+pi install npm:@zenmux/pi-zenmux-oauth
+```
+
+启动 Pi 后登录：
+
+```text
+/login zenmux
+```
+
+在浏览器中确认授权。回调页面显示连接成功后返回 Pi，运行 `/model` 并选择 ZenMux 模型。
+
+该扩展会：
+
+- 动态获取 ZenMux 模型目录，并将最后一次有效目录缓存到 `~/.pi/agent/models-store.json`。
+- 根据 ZenMux 为每个模型声明的协议，选择 Anthropic Messages、OpenAI Responses 或 Chat Completions。
+- 在 Pi 的 Provider 凭据存储中保存 Access Token 与 Refresh Token，并保存轮换后的 Refresh Token。
+- 仅申请 `inference:invoke` 和 `offline_access` 权限。
+
+如需退出登录，在 Pi 中运行 `/logout` 并选择 ZenMux。也可以在 ZenMux 的已授权应用中撤销授权。
+
+授权流程和凭据安全的详细说明请参阅 [OAuth PKCE 接入指南](/zh/best-practices/oauth-pkce)。
+
+## 如何选择
+
+| 能力 | 普通 API Key | OAuth PKCE |
+| --- | --- | --- |
+| 认证方式 | `ZENMUX_API_KEY` | 浏览器授权 |
+| 额外扩展 | 不需要 | `@zenmux/pi-zenmux-oauth` |
+| 模型配置 | 在 `models.json` 中添加模型 ID | 自动获取模型目录 |
+| 协议选择 | 由 `models.json` 中的 `api` 决定 | 根据 ZenMux 模型目录逐模型选择 |
+| 凭据生命周期 | 用户自行管理 | 自动刷新并轮换 Access Token |
+
+## 常见问题
+
+### 找不到 ZenMux 模型
+
+使用普通 API Key 时，请确认：
+
+- `~/.pi/agent/models.json` 是合法的 JSON。
+- Provider 包含 `baseUrl`、`api` 和至少一个模型 ID。
+- 启动 Pi 的同一个终端中存在 `ZENMUX_API_KEY`。
+
+可以直接检查 Pi 已加载的模型：
+
+```bash
+pi --list-models zenmux
+```
+
+使用 OAuth 时，请确认扩展已经安装：
+
+```bash
+pi list
+```
+
+必要时更新扩展并重新登录：
+
+```bash
+pi update npm:@zenmux/pi-zenmux-oauth
+```
+
+### 浏览器已经打开，但授权无法完成
+
+OAuth 回调使用 `127.0.0.1` 上的临时端口，浏览器和 Pi 必须访问同一台机器的回环地址。远程服务器、容器、SSH 会话或浏览器代理环境可能需要端口转发，或者改为在本机运行 Pi。
+
+### 请求返回 401
+
+- 普通 API Key：确认 `ZENMUX_API_KEY` 仍然有效，并且在启动 Pi 前已经导出。
+- OAuth：重新运行 `/login zenmux`。如果仍然失败，请先在 ZenMux 已授权应用中撤销旧授权，再重新登录。
+
+不要把 API Key 或 OAuth Token 粘贴到提示词、项目文件、日志或截图中。

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -423,6 +423,10 @@ export default defineLoacaleConfig({
               link: "/zh/best-practices/open-webui",
             },
             {
+              text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/08/17/AiPNvoR/Pi-Logo-black-outline.svg" />Pi Coding Agent 接入 ZenMux 指南',
+              link: "/zh/best-practices/pi-coding-agent",
+            },
+            {
               text: '<img src="https://cdn.marmot-cloud.com/storage/zenmux/2026/05/18/mFIxohk/Property-1RikkaHub.svg" />RikkaHub 接入 ZenMux 指南',
               link: "/zh/best-practices/rikkahub",
             },


### PR DESCRIPTION
## What changed

- Add bilingual Pi Coding Agent integration guides.
- Document both standard `ZENMUX_API_KEY` configuration and OAuth PKCE through `@zenmux/pi-zenmux-oauth`.
- Use the current `@earendil-works/pi-coding-agent` package and explain migration from the deprecated package name.
- Add Pi Coding Agent to the English and Chinese Integrations menus with the supplied ZenMux CDN logo.

## Why

Pi was covered only as a subsection of the general OAuth PKCE guide. Users need a standalone guide that also explains ordinary API key configuration, model selection, credential handling, and troubleshooting.

## Validation

- Installed and ran Pi `0.84.2` in an isolated directory.
- Confirmed Pi loads the `ZENMUX_API_KEY` reference and `deepseek-v4-flash` from `models.json`.
- Confirmed `@zenmux/pi-zenmux-oauth` installs and updates through Pi's package commands.
- `git diff --staged --check`
- `pnpm exec vitepress build docs_source --outDir /tmp/zenmux-pi-coding-agent-pr-build`
