### PR TITLE
docs: add RSS subscription guide

### DIFF
--- a/docs_source/en/config.ts
+++ b/docs_source/en/config.ts
@@ -103,6 +103,7 @@ const docsSidebar = [
     items: [
       { text: "Privacy Policy", link: "/privacy" },
       { text: "Terms of Service", link: "/terms-of-service" },
+      { text: "RSS Feeds", link: "/help/rss" },
       { text: "Contact Us", link: "/help/contact" },
     ],
   },

--- a/docs_source/en/help/rss.md
+++ b/docs_source/en/help/rss.md
@@ -1,0 +1,65 @@
+---
+head:
+  - - meta
+    - name: description
+      content: Subscribe to ZenMux changelog, notices, and model updates via RSS
+  - - meta
+    - name: keywords
+      content: ZenMux, RSS, feed, changelog, notification, models, subscribe
+---
+
+# RSS Feeds
+
+ZenMux publishes public RSS 2.0 feeds so you can follow product updates, platform notices, and new models from a reader, monitoring system, or automation workflow. No login or API Key is required.
+
+::: tip Recommended feed
+If you only want one URL, subscribe to [All updates](https://zenmux.ai/rss/all.xml). It includes changelog entries, notices, and model updates.
+:::
+
+## Feed URLs
+
+| Feed | Contents | URL |
+| --- | --- | --- |
+| Changelog | Product releases and release notes | [https://zenmux.ai/rss/changelog.xml](https://zenmux.ai/rss/changelog.xml) |
+| Notices | Public notices such as model retirement warnings | [https://zenmux.ai/rss/notification.xml](https://zenmux.ai/rss/notification.xml) |
+| Models | New model launches and model-related updates | [https://zenmux.ai/rss/models.xml](https://zenmux.ai/rss/models.xml) |
+| All updates | Combined feed of the three sources above | [https://zenmux.ai/rss/all.xml](https://zenmux.ai/rss/all.xml) |
+
+## How to subscribe
+
+Add the URL to any RSS-capable client, for example:
+
+- Readers such as Feedly, Inoreader, NetNewsWire, or Reeder
+- Slack, Discord, or email gateways that accept RSS
+- Custom monitors that poll the XML on a schedule
+
+Most readers support “Add subscription by URL”. Paste a feed URL from the table above.
+
+## Feed fields
+
+All feeds are RSS 2.0. Common fields:
+
+| Field | Description |
+| --- | --- |
+| `channel/title` | Feed name, for example `ZenMux Changelog` |
+| `channel/description` | Short description of the feed |
+| `item/title` | Item title |
+| `item/link` | Detail URL (model items usually point to the model page; changelog items point to [Changelog](https://zenmux.ai/changelog)) |
+| `item/guid` | Stable unique ID for deduplication |
+| `item/pubDate` | Publication time (GMT) |
+| `item/category` | Category: `Changelog`, `Notice`, or `Models` |
+| `item/description` | Summary. Some new-model items may have an empty description; use the title and link |
+
+`all.xml` mixes all three types. Filter by `category` if you need a subset.
+
+## Suggested uses
+
+- **Engineering and operations**: subscribe to notices so you catch model retirements or provider changes.
+- **Product and research**: subscribe to the models feed for new launches.
+- **Product changes**: subscribe to the changelog for feature releases and behavior changes.
+- **Automation**: deduplicate with `guid` so the same item is not processed twice.
+
+::: info Related pages
+- Web changelog: [https://zenmux.ai/changelog](https://zenmux.ai/changelog)
+- Model catalog: [https://zenmux.ai/models](https://zenmux.ai/models)
+:::

--- a/docs_source/zh/config.ts
+++ b/docs_source/zh/config.ts
@@ -100,6 +100,7 @@ const docsSidebar = [
     items: [
       { text: "隐私政策", link: "/zh/privacy" },
       { text: "服务协议", link: "/zh/terms-of-service" },
+      { text: "RSS 订阅", link: "/zh/help/rss" },
       { text: "联系我们", link: "/zh/help/contact" },
     ],
   },

--- a/docs_source/zh/help/rss.md
+++ b/docs_source/zh/help/rss.md
@@ -1,0 +1,65 @@
+---
+head:
+  - - meta
+    - name: description
+      content: 通过 RSS 订阅 ZenMux 更新日志、公告和模型上新
+  - - meta
+    - name: keywords
+      content: ZenMux, RSS, feed, changelog, notification, models, 订阅
+---
+
+# RSS 订阅
+
+ZenMux 提供公开 RSS 2.0 订阅源，方便你在阅读器、监控系统或自动化工作流中及时获取产品更新、平台公告和模型上新。无需登录，也无需 API Key。
+
+::: tip 推荐订阅
+如果只想维护一个订阅地址，使用 [全部更新](https://zenmux.ai/rss/all.xml) 即可覆盖更新日志、公告和模型动态。
+:::
+
+## 订阅地址
+
+| 订阅源 | 内容 | 地址 |
+| --- | --- | --- |
+| 更新日志 | 产品功能发布与版本说明 | [https://zenmux.ai/rss/changelog.xml](https://zenmux.ai/rss/changelog.xml) |
+| 公告通知 | 公开公告，例如模型下线、停用提醒 | [https://zenmux.ai/rss/notification.xml](https://zenmux.ai/rss/notification.xml) |
+| 模型动态 | 新模型上线与模型相关更新 | [https://zenmux.ai/rss/models.xml](https://zenmux.ai/rss/models.xml) |
+| 全部更新 | 以上三类内容的合集 | [https://zenmux.ai/rss/all.xml](https://zenmux.ai/rss/all.xml) |
+
+## 如何订阅
+
+将对应地址添加到任意支持 RSS 的客户端即可，例如：
+
+- Feedly、Inoreader、NetNewsWire、Reeder 等阅读器
+- Slack、Discord、邮件网关等支持 RSS 入站的集成
+- 自建监控脚本（按固定间隔拉取 XML）
+
+多数阅读器支持「通过 URL 添加订阅」。把上表中的地址粘贴进去即可。
+
+## Feed 字段说明
+
+各订阅源均为 RSS 2.0。常见字段如下：
+
+| 字段 | 说明 |
+| --- | --- |
+| `channel/title` | 订阅源名称，例如 `ZenMux Changelog` |
+| `channel/description` | 订阅源简介 |
+| `item/title` | 条目标题 |
+| `item/link` | 详情页链接（模型条目通常指向模型页，更新日志指向 [Changelog](https://zenmux.ai/changelog)） |
+| `item/guid` | 条目唯一标识，可用于去重 |
+| `item/pubDate` | 发布时间（GMT） |
+| `item/category` | 分类：`Changelog`、`Notice` 或 `Models` |
+| `item/description` | 正文摘要。部分模型上新条目可能为空，请以标题和链接为准 |
+
+`all.xml` 会混合三类条目，可用 `category` 再做过滤。
+
+## 使用建议
+
+- **开发与运维**：订阅公告源，及时感知模型下线或供应商变更。
+- **产品与研究**：订阅模型源，跟进新模型上线。
+- **关注产品演进**：订阅更新日志，了解功能发布与行为变化。
+- **自动化**：用 `guid` 去重，避免重复处理同一条目。
+
+::: info 相关页面
+- 网页版更新日志：[https://zenmux.ai/changelog](https://zenmux.ai/changelog)
+- 模型列表：[https://zenmux.ai/models](https://zenmux.ai/models)
+:::


### PR DESCRIPTION
## Summary
- Add bilingual RSS subscription docs covering changelog, notices, models, and the combined feed.
- Add Help Center sidebar entries for Chinese and English.

## Test plan
- [ ] Open `/zh/help/rss` and `/help/rss` in docs preview
- [ ] Confirm the four feed URLs and sidebar links